### PR TITLE
Add BsonCodec and scalacheck properties

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
     val scalaTest = "3.0.5"
     val mongoScalaBson = "2.6.0"
     val cats = "1.6.0"
+    val scalaCheck = "1.14.0"
   }
 
   lazy val Libraries = libraryDependencies ++= Vector(
@@ -15,5 +16,6 @@ object Dependencies {
 
   lazy val TestLibraries = libraryDependencies ++= Vector(
     "org.scalatest" %% "scalatest" % Versions.scalaTest,
+    "org.scalacheck" %% "scalacheck" % Versions.scalaCheck
   ).map(_ % Test)
 }

--- a/src/main/scala/medeia/BsonCodec.scala
+++ b/src/main/scala/medeia/BsonCodec.scala
@@ -1,0 +1,33 @@
+package medeia
+
+import cats.Invariant
+import cats.data.EitherNec
+import medeia.decoder.{BsonDecoder, BsonDecoderError}
+import medeia.encoder.BsonEncoder
+import org.mongodb.scala.bson.BsonValue
+
+trait BsonCodec[A] extends BsonEncoder[A] with BsonDecoder[A]
+
+object BsonCodec {
+  def apply[A: BsonCodec]: BsonCodec[A] = implicitly
+
+  implicit def fromEncoderAndDecoder[A: BsonEncoder: BsonDecoder](
+      implicit encoder: BsonEncoder[A],
+      decoder: BsonDecoder[A]): BsonCodec[A] = new BsonCodec[A] {
+    override def encode(a: A): BsonValue = encoder.encode(a)
+
+    override def decode(bson: BsonValue): EitherNec[BsonDecoderError, A] =
+      decoder.decode(bson)
+  }
+
+  implicit val bsonCodecInvariant: Invariant[BsonCodec] =
+    new Invariant[BsonCodec] {
+      override def imap[A, B](fa: BsonCodec[A])(f: A => B)(
+          g: B => A): BsonCodec[B] = new BsonCodec[B] {
+        override def encode(b: B): BsonValue = fa.encode(g(b))
+
+        override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
+          fa.decode(bson).map(f)
+      }
+    }
+}

--- a/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -15,7 +15,7 @@ import scala.collection.generic.CanBuildFrom
 
 trait BsonDecoder[A] { self =>
 
-  def decode(a: BsonValue): EitherNec[BsonDecoderError, A]
+  def decode(bson: BsonValue): EitherNec[BsonDecoderError, A]
 
   def map[B](f: A => B): BsonDecoder[B] = x => self.decode(x).map(f(_))
 }
@@ -23,10 +23,10 @@ trait BsonDecoder[A] { self =>
 object BsonDecoder extends DefaultBsonDecoderInstances {
   def apply[A: BsonDecoder]: BsonDecoder[A] = implicitly
 
-  def decode[A: BsonDecoder](a: BsonValue): EitherNec[BsonDecoderError, A] = {
-    BsonDecoder[A].decode(a)
+  def decode[A: BsonDecoder](
+      bson: BsonValue): EitherNec[BsonDecoderError, A] = {
+    BsonDecoder[A].decode(bson)
   }
-
 }
 
 trait DefaultBsonDecoderInstances extends BsonDecoderLowPriorityInstances {

--- a/src/test/scala/medeia/Arbitraries.scala
+++ b/src/test/scala/medeia/Arbitraries.scala
@@ -1,0 +1,17 @@
+package medeia
+
+import java.time.Instant
+
+import org.scalacheck.{Arbitrary, Gen}
+
+trait Arbitraries {
+  implicit val arbitraryInstant: Arbitrary[Instant] = Arbitrary[Instant] {
+    Gen.calendar.map(_.toInstant)
+  }
+
+  implicit val arbitrarySymbol: Arbitrary[Symbol] = Arbitrary[Symbol] {
+    Gen.asciiStr.map(Symbol(_))
+  }
+}
+
+object Arbitraries extends Arbitraries

--- a/src/test/scala/medeia/BsonCodecProperties.scala
+++ b/src/test/scala/medeia/BsonCodecProperties.scala
@@ -1,0 +1,47 @@
+package medeia
+
+import java.time.Instant
+import java.util.Date
+
+import medeia.decoder.BsonDecoder
+import medeia.syntax._
+import org.scalacheck.{Arbitrary, Prop, Properties}
+
+class BsonCodecProperties extends Properties("BsonEncoder") with Arbitraries {
+  propertyWithSeed("decode after encode === id (boolean)", None) = {
+    codecProperty[Boolean]
+  }
+
+  propertyWithSeed("decode after encode === id (string)", None) = {
+    codecProperty[String]
+  }
+
+  propertyWithSeed("decode after encode === id (long)", None) = {
+    codecProperty[Long]
+  }
+
+  propertyWithSeed("decode after encode === id (double)", None) = {
+    codecProperty[Double]
+  }
+
+  propertyWithSeed("decode after encode === id (instant)", None) = {
+    codecProperty[Instant]
+  }
+
+  propertyWithSeed("decode after encode === id (date)", None) = {
+    codecProperty[Date]
+  }
+
+  propertyWithSeed("decode after encode === id (binary)", None) = {
+    codecProperty[Array[Byte]]
+  }
+
+  propertyWithSeed("decode after encode === id (symbol)", None) = {
+    codecProperty[Symbol]
+  }
+
+  private[this] def codecProperty[A: Arbitrary: BsonCodec]: Prop =
+    Prop.forAll { original: A =>
+      BsonDecoder.decode[A](original.toBson) == Right(original)
+    }
+}


### PR DESCRIPTION
Adds:

- BsonCodec which proves the existence of both a BsonDecoder and BsonEncoder
- ScalaCheck properties for the currently built-in types