### PR TITLE
Add Decoders from BsonValue to subtypes

### DIFF
--- a/src/test/scala/medeia/BsonDecoderSpec.scala
+++ b/src/test/scala/medeia/BsonDecoderSpec.scala
@@ -1,0 +1,32 @@
+package medeia
+
+import medeia.decoder.BsonDecoder
+import org.mongodb.scala.bson.collection.immutable
+import org.mongodb.scala.bson.collection.mutable
+import org.mongodb.scala.bson.{BsonDocument, BsonElement, BsonInt32, BsonString}
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class BsonDecoderSpec extends FlatSpec with Matchers with TypeCheckedTripleEquals {
+  behavior of "BsonDecoder"
+
+  it should "decode BsonValue into BsonDocument" in {
+    val doc = new BsonDocument(List(new BsonElement("answer", new BsonInt32(42)), new BsonElement("question", new BsonString("???"))).asJava)
+
+    BsonDecoder[BsonDocument].decode(doc) should be('right)
+  }
+
+  it should "decode BsonValue into immutable Document" in {
+    val doc = new BsonDocument(List(new BsonElement("answer", new BsonInt32(42)), new BsonElement("question", new BsonString("???"))).asJava)
+
+    BsonDecoder[immutable.Document].decode(doc) should be('right)
+  }
+
+  it should "decode BsonValue into mutable Document" in {
+    val doc = new BsonDocument(List(new BsonElement("answer", new BsonInt32(42)), new BsonElement("question", new BsonString("???"))).asJava)
+
+    BsonDecoder[mutable.Document].decode(doc) should be('right)
+  }
+}


### PR DESCRIPTION
Adds decoders for the subtypes of `BsonValue`

This is handy for example if you only want to go from `BsonValue` to `Document` and then work on that.

Also some small refactoring.