### PR TITLE
Add encoders and decoders for BsonValue

### DIFF
--- a/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -97,6 +97,8 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
 
   implicit def chainDecoder[A: BsonDecoder]: BsonDecoder[Chain[A]] = listDecoder[A].map(Chain.fromSeq)
 
+  implicit val bsonValueDecoder: BsonDecoder[BsonValue] = Either.rightNec(_)
+
   implicit val bsonArrayDecoder: BsonDecoder[BsonArray] = withType(BsonType.ARRAY)(_.asArray)
 
   implicit val bsonBinaryDecoder: BsonDecoder[BsonBinary] = withType(BsonType.BINARY)(_.asBinary)

--- a/src/main/scala/medeia/encoder/BsonEncoder.scala
+++ b/src/main/scala/medeia/encoder/BsonEncoder.scala
@@ -6,6 +6,7 @@ import java.util.{Date, UUID}
 import cats.Contravariant
 import cats.data.Chain
 import org.mongodb.scala.bson._
+import org.mongodb.scala.bson.collection.{immutable, mutable}
 
 trait BsonEncoder[A] { self =>
   def encode(value: A): BsonValue
@@ -57,6 +58,12 @@ trait DefaultBsonEncoderInstances extends BsonIterableEncoder {
   implicit def vectorEncoder[A: BsonEncoder]: BsonEncoder[Vector[A]] = iterableEncoder[A].contramap(_.toIterable)
 
   implicit def chainEncoder[A: BsonEncoder]: BsonEncoder[Chain[A]] = iterableEncoder[A].contramap(_.toList.toIterable)
+
+  implicit def bsonValueEncoder[A <: BsonValue]: BsonEncoder[A] = value => value
+
+  implicit val immutableDocumentEncoder: BsonEncoder[immutable.Document] = _.toBsonDocument
+
+  implicit val mutableDocumentEncoder: BsonEncoder[mutable.Document] = _.toBsonDocument
 }
 
 trait BsonIterableEncoder {

--- a/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
+++ b/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
@@ -1,8 +1,7 @@
-package medeia
+package medeia.decoder
 
-import medeia.decoder.BsonDecoder
-import org.mongodb.scala.bson.collection.immutable
-import org.mongodb.scala.bson.collection.mutable
+import org.bson.BsonValue
+import org.mongodb.scala.bson.collection.{immutable, mutable}
 import org.mongodb.scala.bson.{BsonDocument, BsonElement, BsonInt32, BsonString}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{FlatSpec, Matchers}
@@ -28,5 +27,11 @@ class BsonDecoderSpec extends FlatSpec with Matchers with TypeCheckedTripleEqual
     val doc = new BsonDocument(List(new BsonElement("answer", new BsonInt32(42)), new BsonElement("question", new BsonString("???"))).asJava)
 
     BsonDecoder[mutable.Document].decode(doc) should be('right)
+  }
+
+  it should "decode BsonValue into BsonValue" in {
+    val bsonValue: BsonValue = new BsonString("")
+
+    BsonDecoder[BsonValue].decode(bsonValue) should ===(Right(bsonValue))
   }
 }

--- a/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
+++ b/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
@@ -1,0 +1,33 @@
+package medeia.encoder
+
+import medeia.BsonCodec
+import org.mongodb.scala.bson.{BsonInt32, BsonString, BsonValue}
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{FlatSpec, Matchers}
+
+class BsonEncoderSpec extends FlatSpec with Matchers with TypeCheckedTripleEquals {
+  behavior of "BsonEncoder"
+
+  it should "encode BsonValue" in {
+    val input = new BsonString("")
+
+    val encoded = BsonEncoder[BsonValue].encode(input)
+
+    encoded should ===(input)
+  }
+
+  it should "encode case class with BsonValues" in {
+    import medeia.generic.semiauto._
+    import medeia.syntax._
+
+    case class Foo(bsonString: BsonString, bsonInt32: BsonInt32)
+
+    val input = Foo(new BsonString("string"), new BsonInt32(42))
+
+    implicit val fooCodec: BsonCodec[Foo] = deriveCodec[Foo]
+
+    val result = input.toBson.fromBson[Foo]
+
+    result should ===(Right(input))
+  }
+}


### PR DESCRIPTION
Adds encoders and decoders for `BsonValue` and the subtypes.

Handy for example if you have a `case class Foo(bsonArray: BsonArray)` for which we could not derive the codec because there is none for `BsonArray`