### PR TITLE
Rename derive* methods to include Bson prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ medeia includes decoders and encoders for common data structures as well as auto
   import medeia.syntax._
 
   case class Simple(int: Int, string: Option[String])
-  implicit val simpleEncoder: BsonEncoder[Simple] = deriveEncoder
+  implicit val simpleEncoder: BsonEncoder[Simple] = deriveBsonEncoder
   val encoded = Simple(1, Some("a")).toBson
   // {"string": "a", "int": 1}
 
-  implicit val simpleDecoder: BsonDecoder[Simple] = deriveDecoder
+  implicit val simpleDecoder: BsonDecoder[Simple] = deriveBsonDecoder
   val doc = BsonDocument("int" -> 1, "string" -> "string")
   val decoded = doc.fromBson[Simple]
   // Right(Simple(1,Some(string)))
@@ -66,7 +66,7 @@ A transformation function for keynames can be provided as follows:
   case class Simple(fieldInScala: Int)
   implicit val genericDerivationOptions: GenericDerivationOptions[Simple] =
     GenericDerivationOptions { case "fieldInScala" => "fieldInBson" }
-  implicit val simpleEncoder: BsonEncoder[Simple] = deriveEncoder
+  implicit val simpleEncoder: BsonEncoder[Simple] = deriveBsonEncoder
   val encoded = Simple(1).toBson
   // {"fieldInBson": 1}
 ```

--- a/src/main/scala/medeia/generic/semiauto/Semiauto.scala
+++ b/src/main/scala/medeia/generic/semiauto/Semiauto.scala
@@ -7,13 +7,13 @@ import medeia.generic.{GenericDecoder, GenericEncoder}
 import shapeless.Lazy
 
 trait Semiauto {
-  def deriveEncoder[A](implicit genericEncoder: Lazy[GenericEncoder[A]]): BsonDocumentEncoder[A] = genericEncoder.value
+  def deriveBsonEncoder[A](implicit genericEncoder: Lazy[GenericEncoder[A]]): BsonDocumentEncoder[A] = genericEncoder.value
 
-  def deriveDecoder[A](implicit genericDecoder: Lazy[GenericDecoder[A]]): BsonDecoder[A] = genericDecoder.value
+  def deriveBsonDecoder[A](implicit genericDecoder: Lazy[GenericDecoder[A]]): BsonDecoder[A] = genericDecoder.value
 
-  def deriveCodec[A](implicit
-                     genericEncoder: GenericEncoder[A],
-                     genericDecoder: GenericDecoder[A]): BsonCodec[A] = {
+  def deriveBsonCodec[A](implicit
+                         genericEncoder: GenericEncoder[A],
+                         genericDecoder: GenericDecoder[A]): BsonCodec[A] = {
     BsonCodec.fromEncoderAndDecoder
   }
 }

--- a/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
+++ b/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
@@ -24,7 +24,7 @@ class BsonEncoderSpec extends FlatSpec with Matchers with TypeCheckedTripleEqual
 
     val input = Foo(new BsonString("string"), new BsonInt32(42))
 
-    implicit val fooCodec: BsonCodec[Foo] = deriveCodec[Foo]
+    implicit val fooCodec: BsonCodec[Foo] = deriveBsonCodec[Foo]
 
     val result = input.toBson.fromBson[Foo]
 

--- a/src/test/scala/medeia/generic/semiauto/SemiautoSpec.scala
+++ b/src/test/scala/medeia/generic/semiauto/SemiautoSpec.scala
@@ -6,15 +6,15 @@ class SemiautoSpec extends FlatSpec with Matchers {
   case class Simple(int: String)
 
   "Semiauto" should "be able to derive an encoder from a case class" in {
-    deriveEncoder[Simple]
+    deriveBsonEncoder[Simple]
   }
 
   it should "be able to derive a decoder from a case class" in {
-    val _: medeia.decoder.BsonDecoder[Simple] = deriveDecoder
+    val _: medeia.decoder.BsonDecoder[Simple] = deriveBsonDecoder
   }
 
   it should "be able to derive a codec from a case class" in {
-    val _: medeia.BsonCodec[Simple] = deriveCodec
+    val _: medeia.BsonCodec[Simple] = deriveBsonCodec
   }
 
   "The default summoning method" should "not be able to access GenericEncoders without import" in {


### PR DESCRIPTION
So we don't clash with `circe`'s `derive*` methods