### PR TITLE
Add MedeiaSpec

### DIFF
--- a/src/test/scala/medeia/MedeiaSpec.scala
+++ b/src/test/scala/medeia/MedeiaSpec.scala
@@ -1,0 +1,6 @@
+package medeia
+
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{EitherValues, FlatSpecLike, Matchers, OptionValues}
+
+trait MedeiaSpec extends FlatSpecLike with TypeCheckedTripleEquals with Matchers with EitherValues with OptionValues

--- a/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
+++ b/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
@@ -1,14 +1,13 @@
 package medeia.decoder
 
+import medeia.MedeiaSpec
 import org.bson.BsonValue
 import org.mongodb.scala.bson.collection.{immutable, mutable}
 import org.mongodb.scala.bson.{BsonDocument, BsonElement, BsonInt32, BsonString}
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.JavaConverters._
 
-class BsonDecoderSpec extends FlatSpec with Matchers with TypeCheckedTripleEquals {
+class BsonDecoderSpec extends MedeiaSpec {
   behavior of "BsonDecoder"
 
   it should "decode BsonValue into BsonDocument" in {

--- a/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
+++ b/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
@@ -1,11 +1,9 @@
 package medeia.encoder
 
-import medeia.BsonCodec
+import medeia.{BsonCodec, MedeiaSpec}
 import org.mongodb.scala.bson.{BsonInt32, BsonString, BsonValue}
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{FlatSpec, Matchers}
 
-class BsonEncoderSpec extends FlatSpec with Matchers with TypeCheckedTripleEquals {
+class BsonEncoderSpec extends MedeiaSpec {
   behavior of "BsonEncoder"
 
   it should "encode BsonValue" in {

--- a/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -1,15 +1,14 @@
 package medeia.generic
 
 import cats.data.NonEmptyChain
+import medeia.MedeiaSpec
 import medeia.decoder.BsonDecoderError.{KeyNotFound, TypeMismatch}
 import medeia.generic.auto._
 import medeia.syntax._
 import org.bson.BsonType
 import org.mongodb.scala.bson.{BsonDocument, BsonNull}
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
-class GenericDecoderSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
+class GenericDecoderSpec extends MedeiaSpec {
 
   "GenericDecoder" should "handle errors" in {
     case class Simple(int: Int, string: String)

--- a/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -1,12 +1,11 @@
 package medeia.generic
 
+import medeia.MedeiaSpec
 import medeia.generic.auto._
 import medeia.syntax._
 import org.mongodb.scala.bson.BsonDocument
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
-class GenericEncoderSpec extends FlatSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
+class GenericEncoderSpec extends MedeiaSpec {
 
   "GenericEncoder" should "allow for key transformation" in {
     case class Simple(int: Int, string: String)

--- a/src/test/scala/medeia/generic/semiauto/SemiautoSpec.scala
+++ b/src/test/scala/medeia/generic/semiauto/SemiautoSpec.scala
@@ -1,8 +1,8 @@
 package medeia.generic.semiauto
 
-import org.scalatest.{FlatSpec, Matchers}
+import medeia.MedeiaSpec
 
-class SemiautoSpec extends FlatSpec with Matchers {
+class SemiautoSpec extends MedeiaSpec {
   case class Simple(int: String)
 
   "Semiauto" should "be able to derive an encoder from a case class" in {

--- a/src/test/scala/medeia/syntax/MedeiaSyntaxSpec.scala
+++ b/src/test/scala/medeia/syntax/MedeiaSyntaxSpec.scala
@@ -1,11 +1,10 @@
 package medeia.syntax
 
+import medeia.MedeiaSpec
 import medeia.decoder.BsonDecoder
 import medeia.encoder.BsonDocumentEncoder
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
 
-class MedeiaSyntaxSpec extends FlatSpec with Matchers with TypeCheckedTripleEquals with EitherValues with OptionValues {
+class MedeiaSyntaxSpec extends MedeiaSpec {
   behavior of classOf[MedeiaSyntax].getSimpleName
 
   it should "enrich values that have a bson encoder instance" in {


### PR DESCRIPTION
Introduces `MedeiaSpec`, which already pulls in most of the usual scalatest traits.

Should be rebased and merged *after* #30 ;)