### PR TITLE
Add BsonDocumentCodec, imap and summoners

### DIFF
--- a/src/main/scala/medeia/codec/BsonCodec.scala
+++ b/src/main/scala/medeia/codec/BsonCodec.scala
@@ -1,4 +1,4 @@
-package medeia
+package medeia.codec
 
 import cats.Invariant
 import cats.data.EitherNec
@@ -6,9 +6,18 @@ import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.encoder.BsonEncoder
 import org.mongodb.scala.bson.BsonValue
 
-trait BsonCodec[A] extends BsonEncoder[A] with BsonDecoder[A]
+trait BsonCodec[A] extends BsonEncoder[A] with BsonDecoder[A] { self =>
+  def imap[B](f: A => B)(g: B => A): BsonCodec[B] = new BsonCodec[B] {
+    override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
+      self.decode(bson).map(f)
+
+    override def encode(value: B): BsonValue = self.encode(g(value))
+  }
+}
 
 object BsonCodec {
+  def apply[A](implicit codec: BsonCodec[A]): BsonCodec[A] = codec
+
   implicit def fromEncoderAndDecoder[A](implicit encoder: BsonEncoder[A], decoder: BsonDecoder[A]): BsonCodec[A] =
     new BsonCodec[A] {
       override def encode(a: A): BsonValue = encoder.encode(a)
@@ -19,11 +28,6 @@ object BsonCodec {
 
   implicit def invariantInstance: Invariant[BsonCodec] =
     new Invariant[BsonCodec] {
-      override def imap[A, B](fa: BsonCodec[A])(f: A => B)(g: B => A): BsonCodec[B] = new BsonCodec[B] {
-        override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
-          fa.decode(bson).map(f)
-
-        override def encode(value: B): BsonValue = fa.encode(g(value))
-      }
+      override def imap[A, B](fa: BsonCodec[A])(f: A => B)(g: B => A): BsonCodec[B] = fa.imap(f)(g)
     }
 }

--- a/src/main/scala/medeia/codec/BsonDocumentCodec.scala
+++ b/src/main/scala/medeia/codec/BsonDocumentCodec.scala
@@ -1,0 +1,33 @@
+package medeia.codec
+
+import cats.Invariant
+import cats.data.EitherNec
+import medeia.decoder.{BsonDecoder, BsonDecoderError}
+import medeia.encoder.BsonDocumentEncoder
+import org.bson.{BsonDocument, BsonValue}
+
+trait BsonDocumentCodec[A] extends BsonCodec[A] with BsonDocumentEncoder[A] { self =>
+  override def imap[B](f: A => B)(g: B => A): BsonDocumentCodec[B] = new BsonDocumentCodec[B] {
+    override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
+      self.decode(bson).map(f)
+
+    override def encode(value: B): BsonDocument = self.encode(g(value))
+  }
+}
+
+object BsonDocumentCodec {
+  def apply[A](implicit codec: BsonDocumentCodec[A]): BsonDocumentCodec[A] = codec
+
+  implicit def fromEncoderAndDecoder[A](implicit encoder: BsonDocumentEncoder[A], decoder: BsonDecoder[A]): BsonDocumentCodec[A] =
+    new BsonDocumentCodec[A] {
+      override def encode(a: A): BsonDocument = encoder.encode(a)
+
+      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, A] =
+        decoder.decode(bson)
+    }
+
+  implicit def invariantInstance: Invariant[BsonDocumentCodec] =
+    new Invariant[BsonDocumentCodec] {
+      override def imap[A, B](fa: BsonDocumentCodec[A])(f: A => B)(g: B => A): BsonDocumentCodec[B] = fa.imap(f)(g)
+    }
+}

--- a/src/main/scala/medeia/generic/semiauto/Semiauto.scala
+++ b/src/main/scala/medeia/generic/semiauto/Semiauto.scala
@@ -1,6 +1,6 @@
 package medeia.generic.semiauto
 
-import medeia.BsonCodec
+import medeia.codec.BsonDocumentCodec
 import medeia.decoder.BsonDecoder
 import medeia.encoder.BsonDocumentEncoder
 import medeia.generic.{GenericDecoder, GenericEncoder}
@@ -13,7 +13,7 @@ trait Semiauto {
 
   def deriveBsonCodec[A](implicit
                          genericEncoder: GenericEncoder[A],
-                         genericDecoder: GenericDecoder[A]): BsonCodec[A] = {
-    BsonCodec.fromEncoderAndDecoder
+                         genericDecoder: GenericDecoder[A]): BsonDocumentCodec[A] = {
+    BsonDocumentCodec.fromEncoderAndDecoder
   }
 }

--- a/src/test/scala/medeia/codec/BsonCodecProperties.scala
+++ b/src/test/scala/medeia/codec/BsonCodecProperties.scala
@@ -1,9 +1,10 @@
-package medeia
+package medeia.codec
 
 import java.time.Instant
 import java.util.{Date, UUID}
 
 import cats.data.Chain
+import medeia.Arbitraries
 import medeia.decoder.BsonDecoder
 import medeia.syntax._
 import org.scalacheck.{Arbitrary, Prop, Properties}

--- a/src/test/scala/medeia/codec/BsonCodecSpec.scala
+++ b/src/test/scala/medeia/codec/BsonCodecSpec.scala
@@ -1,0 +1,18 @@
+package medeia.codec
+
+import medeia.MedeiaSpec
+
+class BsonCodecSpec extends MedeiaSpec {
+  behavior of "BsonCodec"
+
+  it should "support imap" in {
+    val codec = BsonCodec[Int]
+    val imappedCodec: BsonCodec[String] = codec.imap(_.toString)(_.toInt)
+
+    val input = "42"
+
+    val result = imappedCodec.decode(imappedCodec.encode(input)).right.value
+
+    result should ===(input)
+  }
+}

--- a/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
+++ b/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
@@ -1,0 +1,22 @@
+package medeia.codec
+
+import medeia.MedeiaSpec
+
+class BsonDocumentCodecSpec extends MedeiaSpec {
+  behavior of "BsonDocumentCodec"
+
+  it should "support imap" in {
+    import medeia.generic.semiauto._
+
+    case class Foo(answer: Int)
+    implicit val codec: BsonDocumentCodec[Foo] = deriveBsonCodec[Foo]
+
+    val imappedCodec: BsonDocumentCodec[Int] = codec.imap(_.answer)(Foo)
+
+    val input = 42
+
+    val result = imappedCodec.decode(imappedCodec.encode(input)).right.value
+
+    result should ===(input)
+  }
+}

--- a/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
+++ b/src/test/scala/medeia/encoder/BsonEncoderSpec.scala
@@ -1,6 +1,7 @@
 package medeia.encoder
 
-import medeia.{BsonCodec, MedeiaSpec}
+import medeia.MedeiaSpec
+import medeia.codec.BsonDocumentCodec
 import org.mongodb.scala.bson.{BsonInt32, BsonString, BsonValue}
 
 class BsonEncoderSpec extends MedeiaSpec {
@@ -22,7 +23,7 @@ class BsonEncoderSpec extends MedeiaSpec {
 
     val input = Foo(new BsonString("string"), new BsonInt32(42))
 
-    implicit val fooCodec: BsonCodec[Foo] = deriveBsonCodec[Foo]
+    implicit val fooCodec: BsonDocumentCodec[Foo] = deriveBsonCodec[Foo]
 
     val result = input.toBson.fromBson[Foo]
 

--- a/src/test/scala/medeia/generic/GenericCodecProperties.scala
+++ b/src/test/scala/medeia/generic/GenericCodecProperties.scala
@@ -1,6 +1,6 @@
 package medeia.generic
 
-import medeia.BsonCodec
+import medeia.codec.BsonCodec
 import org.scalacheck.{Gen, Prop, Properties}
 
 class GenericCodecProperties extends Properties("GenericEncoding") {

--- a/src/test/scala/medeia/generic/semiauto/SemiautoSpec.scala
+++ b/src/test/scala/medeia/generic/semiauto/SemiautoSpec.scala
@@ -1,6 +1,7 @@
 package medeia.generic.semiauto
 
 import medeia.MedeiaSpec
+import medeia.codec.BsonDocumentCodec
 
 class SemiautoSpec extends MedeiaSpec {
   case class Simple(int: String)
@@ -14,7 +15,7 @@ class SemiautoSpec extends MedeiaSpec {
   }
 
   it should "be able to derive a codec from a case class" in {
-    val _: medeia.BsonCodec[Simple] = deriveBsonCodec
+    val _: BsonDocumentCodec[Simple] = deriveBsonCodec
   }
 
   "The default summoning method" should "not be able to access GenericEncoders without import" in {
@@ -26,6 +27,6 @@ class SemiautoSpec extends MedeiaSpec {
   }
 
   it should "not be able to access GenericCodecs without import" in {
-    "medeia.BsonCodec[Simple]" shouldNot typeCheck
+    "medeia.codec.BsonCodec[Simple]" shouldNot typeCheck
   }
 }


### PR DESCRIPTION
Fixes #24 and #25 and #26

- add BsonDocumentCodec
- move codecs into `codec` package
- implement `imap` on both codec types
- add summoners for both codec types