### PR TITLE
Improved error handling

### DIFF
--- a/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -94,7 +94,7 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
 
   implicit val uuidDecoder: BsonDecoder[UUID] = bson =>
     stringDecoder.decode(bson).flatMap { string =>
-      Either.catchOnly[IllegalArgumentException](UUID.fromString(string)).leftMap(FieldParseError(_)).toEitherNec
+      Either.catchOnly[IllegalArgumentException](UUID.fromString(string)).leftMap(FieldParseError("Cannot parse UUID",_)).toEitherNec
   }
 
   implicit def listDecoder[A: BsonDecoder]: BsonDecoder[List[A]] = iterableDecoder

--- a/src/main/scala/medeia/decoder/BsonDecoderError.scala
+++ b/src/main/scala/medeia/decoder/BsonDecoderError.scala
@@ -2,19 +2,12 @@ package medeia.decoder
 
 import org.bson.BsonType
 
-sealed abstract class BsonDecoderError extends Exception
+sealed trait BsonDecoderError
 
 object BsonDecoderError {
-  case class TypeMismatch(actual: BsonType, expected: BsonType) extends BsonDecoderError {
-    override def toString: String = s"expected: $expected, actual: $actual"
+  case class TypeMismatch(actual: BsonType, expected: BsonType) extends Exception(s"expected: $expected, actual: $actual") with BsonDecoderError
 
-  }
+  case class KeyNotFound(keyName: String) extends Exception(s"Key not found: $keyName") with BsonDecoderError
 
-  case class KeyNotFound(keyName: String) extends BsonDecoderError {
-    override def toString: String = s"Key not found: $keyName"
-  }
-
-  case class FieldParseError(error: Exception) extends BsonDecoderError {
-    override def toString: String = s"Field parse Error: ${error.getMessage}"
-  }
+  case class FieldParseError(message: String, cause: Exception = None.orNull) extends Exception(message, cause) with BsonDecoderError
 }

--- a/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
+++ b/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
@@ -28,13 +28,15 @@ object BsonKeyDecoder extends DefaultBsonKeyDecoderInstances {
 trait DefaultBsonKeyDecoderInstances {
   implicit val stringDecoder: BsonKeyDecoder[String] = key => Right(key)
 
-  implicit val intDecoder: BsonKeyDecoder[Int] = key => Either.catchOnly[NumberFormatException](key.toInt).leftMap(FieldParseError(_)).toEitherNec
+  implicit val intDecoder: BsonKeyDecoder[Int] = key =>
+    Either.catchOnly[NumberFormatException](key.toInt).leftMap(FieldParseError("Cannot parse int", _)).toEitherNec
 
-  implicit val longDecoder: BsonKeyDecoder[Long] = key => Either.catchOnly[NumberFormatException](key.toLong).leftMap(FieldParseError(_)).toEitherNec
+  implicit val longDecoder: BsonKeyDecoder[Long] = key =>
+    Either.catchOnly[NumberFormatException](key.toLong).leftMap(FieldParseError("Cannot parse long", _)).toEitherNec
 
   implicit val doubleDecoder: BsonKeyDecoder[Double] = key =>
-    Either.catchOnly[NumberFormatException](key.toDouble).leftMap(FieldParseError(_)).toEitherNec
+    Either.catchOnly[NumberFormatException](key.toDouble).leftMap(FieldParseError("Cannot parse double", _)).toEitherNec
 
   implicit val uuidDecoder: BsonKeyDecoder[UUID] = key =>
-    Either.catchOnly[IllegalArgumentException](UUID.fromString(key)).leftMap(FieldParseError(_)).toEitherNec
+    Either.catchOnly[IllegalArgumentException](UUID.fromString(key)).leftMap(FieldParseError("Cannot parse UUID", _)).toEitherNec
 }


### PR DESCRIPTION
FieldParseError does not need a mandatory Exception

@markus1189 Unsure if the double inheritence from Exception and our BsonDecoderError is the most elegant solution. Any opinion?