### PR TITLE
Increase compile performance on scala 2.13

### DIFF
--- a/project/MiscSettingsPlugin.scala
+++ b/project/MiscSettingsPlugin.scala
@@ -30,7 +30,7 @@ object MiscSettingsPlugin extends AutoPlugin {
 
   lazy val commonSettings = Seq(
     organization := "",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.1",
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => extraScalacOptions ++ extraScalacOptions_2_12

--- a/src/main/scala-2.12/medeia/generic/util/VersionSpecific.scala
+++ b/src/main/scala-2.12/medeia/generic/util/VersionSpecific.scala
@@ -1,0 +1,5 @@
+package medeia.generic.util
+
+object VersionSpecific{
+  type Lazy[+A] = shapeless.Lazy[A]
+}

--- a/src/main/scala-2.13/medeia/generic/util/VersionSpecific.scala
+++ b/src/main/scala-2.13/medeia/generic/util/VersionSpecific.scala
@@ -1,0 +1,11 @@
+package medeia.generic.util
+
+object VersionSpecific{
+  trait Lazy[+A] extends Serializable {
+    def value(): A
+  }
+
+  object Lazy {
+    implicit def instance[A](implicit ev: => A): Lazy[A] = () => ev
+  }
+}

--- a/src/main/scala/medeia/generic/GenericDecoder.scala
+++ b/src/main/scala/medeia/generic/GenericDecoder.scala
@@ -3,8 +3,9 @@ package medeia.generic
 import cats.syntax.either._
 import medeia.decoder.BsonDecoder
 import medeia.decoder.BsonDecoderError.TypeMismatch
+import medeia.generic.util.VersionSpecific.Lazy
 import org.bson.BsonType
-import shapeless.{LabelledGeneric, Lazy}
+import shapeless.LabelledGeneric
 
 trait GenericDecoder[A] extends BsonDecoder[A]
 

--- a/src/main/scala/medeia/generic/GenericEncoder.scala
+++ b/src/main/scala/medeia/generic/GenericEncoder.scala
@@ -1,7 +1,8 @@
 package medeia.generic
 
 import medeia.encoder.BsonDocumentEncoder
-import shapeless.{LabelledGeneric, Lazy}
+import medeia.generic.util.VersionSpecific.Lazy
+import shapeless.LabelledGeneric
 
 trait GenericEncoder[A] extends BsonDocumentEncoder[A]
 

--- a/src/main/scala/medeia/generic/ShapelessDecoder.scala
+++ b/src/main/scala/medeia/generic/ShapelessDecoder.scala
@@ -5,10 +5,11 @@ import cats.instances.parallel._
 import cats.syntax.parallel._
 import medeia.decoder.BsonDecoderError.{InvalidTypeTag, KeyNotFound}
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
+import medeia.generic.util.VersionSpecific.Lazy
 import medeia.syntax._
 import org.mongodb.scala.bson.BsonDocument
 import shapeless.labelled.{FieldType, field}
-import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, Lazy, Witness}
+import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, Witness}
 
 trait ShapelessDecoder[Base, H] {
   def decode(bsonDocument: BsonDocument): EitherNec[BsonDecoderError, H]

--- a/src/main/scala/medeia/generic/ShapelessEncoder.scala
+++ b/src/main/scala/medeia/generic/ShapelessEncoder.scala
@@ -1,8 +1,9 @@
 package medeia.generic
 
 import medeia.encoder.{BsonDocumentEncoder, BsonEncoder}
+import medeia.generic.util.VersionSpecific.Lazy
 import org.mongodb.scala.bson.{BsonDocument, BsonString}
-import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, Lazy, Witness}
+import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, Witness}
 import shapeless.labelled.FieldType
 
 trait ShapelessEncoder[Base, H] {

--- a/src/test/scala/medeia/codec/BsonCodecSpec.scala
+++ b/src/test/scala/medeia/codec/BsonCodecSpec.scala
@@ -11,8 +11,8 @@ class BsonCodecSpec extends MedeiaSpec {
 
     val input = "42"
 
-    val result = imappedCodec.decode(imappedCodec.encode(input)).right.value
+    val result = imappedCodec.decode(imappedCodec.encode(input))
 
-    result should ===(input)
+    result should ===(Right(input))
   }
 }

--- a/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
+++ b/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
@@ -15,8 +15,8 @@ class BsonDocumentCodecSpec extends MedeiaSpec {
 
     val input = 42
 
-    val result = imappedCodec.decode(imappedCodec.encode(input)).right.value
+    val result = imappedCodec.decode(imappedCodec.encode(input))
 
-    result should ===(input)
+    result should ===(Right(input))
   }
 }

--- a/src/test/scala/medeia/codec/BsonKeyCodecSpec.scala
+++ b/src/test/scala/medeia/codec/BsonKeyCodecSpec.scala
@@ -11,8 +11,8 @@ class BsonKeyCodecSpec extends MedeiaSpec {
 
     val input = "42"
 
-    val result = imappedCodec.decode(imappedCodec.encode(input)).right.value
+    val result = imappedCodec.decode(imappedCodec.encode(input))
 
-    result should ===(input)
+    result should ===(Right(input))
   }
 }

--- a/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -13,14 +13,14 @@ class GenericDecoderSpec extends MedeiaSpec {
     import medeia.generic.auto._
     case class Simple(int: Int, string: String)
     val doc = BsonDocument()
-    doc.fromBson[Simple].left.value should ===(NonEmptyChain(KeyNotFound("int"), KeyNotFound("string")))
+    doc.fromBson[Simple] should ===(Left(NonEmptyChain(KeyNotFound("int"), KeyNotFound("string"))))
   }
 
   it should "decode empty values to None" in {
     case class Simple(int: Option[Int])
     val doc = BsonDocument()
     val decoder = semiauto.deriveBsonDecoder[Simple]
-    decoder.decode(doc).right.value should ===(Simple(None))
+    decoder.decode(doc) should ===(Right(Simple(None)))
   }
 
   it should "fail gracefully on nested decoders" in {
@@ -28,7 +28,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     case class Inner(int: Int)
     case class Outer(inner: Inner)
     val doc = BsonDocument(List("inner" -> BsonNull()))
-    doc.fromBson[Outer].left.value should ===(NonEmptyChain(TypeMismatch(BsonType.NULL, BsonType.DOCUMENT)))
+    doc.fromBson[Outer] should ===(Left(NonEmptyChain(TypeMismatch(BsonType.NULL, BsonType.DOCUMENT))))
   }
 
   it should "allow for key transformation" in {
@@ -39,7 +39,7 @@ class GenericDecoderSpec extends MedeiaSpec {
       "string" -> "string"
     )
     implicit val derivationOptions: GenericDerivationOptions[Simple] = GenericDerivationOptions { case "int" => "intA" }
-    doc.fromBson[Simple].right.value should ===(Simple(1, "string"))
+    doc.fromBson[Simple] should ===(Right(Simple(1, "string")))
   }
 
   it should "decode selead trait hierarchies" in {
@@ -54,7 +54,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result.right.value should ===(B(1))
+    result should ===(Right(B(1)))
   }
 
   it should "fail on unknown type tags" in {
@@ -69,7 +69,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result.left.value should ===(NonEmptyChain(InvalidTypeTag("Z")))
+    result should ===(Left(NonEmptyChain(InvalidTypeTag("Z"))))
   }
 
   it should "fail on missing type tags" in {
@@ -83,7 +83,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result.left.value should ===(NonEmptyChain(KeyNotFound("type")))
+    result should ===(Left(NonEmptyChain(KeyNotFound("type"))))
   }
 
   it should "fail on invalid type tags" in {
@@ -98,7 +98,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result.left.value should ===(NonEmptyChain(TypeMismatch(BsonType.INT32, BsonType.STRING)))
+    result should ===(Left(NonEmptyChain(TypeMismatch(BsonType.INT32, BsonType.STRING))))
   }
 
 }

--- a/src/test/scala/medeia/syntax/MedeiaSyntaxSpec.scala
+++ b/src/test/scala/medeia/syntax/MedeiaSyntaxSpec.scala
@@ -14,9 +14,9 @@ class MedeiaSyntaxSpec extends MedeiaSpec {
   it should "enrich values that have a bson encoder instance" in {
     val input = 42
 
-    val result = input.toBson.fromBson[Int].right.value
+    val result = input.toBson.fromBson[Int]
 
-    result should ===(input)
+    result should ===(Right(input))
   }
 
   it should "enrich values that have a bson document encoder instance" in {
@@ -28,18 +28,18 @@ class MedeiaSyntaxSpec extends MedeiaSpec {
 
     val input = Foo(42)
 
-    val result = input.toBson.fromBson[Foo].right.value
+    val result = input.toBson.fromBson[Foo]
 
-    result should ===(input)
+    result should ===(Right(input))
   }
 
   it should "support getSafe for Document" in {
-    Document("existing" -> "foo").getSafe("existing").right.value should ===(BsonString("foo"))
-    Document().getSafe("nonexisting").left.value should ===(NonEmptyChain(KeyNotFound("nonexisting")))
+    Document("existing" -> "foo").getSafe("existing") should ===(Right(BsonString("foo")))
+    Document().getSafe("nonexisting") should ===(Left(NonEmptyChain(KeyNotFound("nonexisting"))))
   }
 
   it should "support getSafe for BsonDocument" in {
-    BsonDocument("existing" -> "foo").getSafe("existing").right.value should ===(BsonString("foo"))
-    BsonDocument().getSafe("nonexisting").left.value should ===(NonEmptyChain(KeyNotFound("nonexisting")))
+    BsonDocument("existing" -> "foo").getSafe("existing") should ===(Right(BsonString("foo")))
+    BsonDocument().getSafe("nonexisting") should ===(Left(NonEmptyChain(KeyNotFound("nonexisting"))))
   }
 }


### PR DESCRIPTION
Use byname implicits on scala 2.13 instead of the shapeless Lazy macro

https://docs.scala-lang.org/sips/byname-implicits.html

fixes #41 

Thanks to @joroKr21 for hinting me to the solution in https://github.com/typelevel/kittens 