### PR TITLE
Use AutoDerivationUnlocker to fix auto derivation priority

### DIFF
--- a/src/main/scala/medeia/generic/auto/auto.scala
+++ b/src/main/scala/medeia/generic/auto/auto.scala
@@ -1,8 +1,8 @@
 package medeia.generic
 
-import medeia.decoder.DefaultBsonDecoderInstances
-import medeia.encoder.DefaultBsonEncoderInstances
+package object auto {
+  type AutoDerivationUnlocked[_] = AutoDerivationUnlocker
+  implicit val unlocker: AutoDerivationUnlocker = new AutoDerivationUnlocker {}
+}
 
-package object auto extends DefaultBsonDecoderInstances with DefaultBsonEncoderInstances with LowPriorityInstances
-
-trait LowPriorityInstances extends GenericEncoderInstances with GenericDecoderInstances
+private[medeia] sealed abstract class AutoDerivationUnlocker

--- a/src/main/scala/medeia/generic/semiauto/Semiauto.scala
+++ b/src/main/scala/medeia/generic/semiauto/Semiauto.scala
@@ -3,8 +3,8 @@ package medeia.generic.semiauto
 import medeia.codec.BsonDocumentCodec
 import medeia.decoder.BsonDecoder
 import medeia.encoder.BsonDocumentEncoder
+import medeia.generic.util.VersionSpecific.Lazy
 import medeia.generic.{GenericDecoder, GenericEncoder}
-import shapeless.Lazy
 
 trait Semiauto {
   def deriveBsonEncoder[A](implicit genericEncoder: Lazy[GenericEncoder[A]]): BsonDocumentEncoder[A] = genericEncoder.value

--- a/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -17,10 +17,10 @@ class GenericDecoderSpec extends MedeiaSpec {
   }
 
   it should "decode empty values to None" in {
+    import medeia.generic.auto._
     case class Simple(int: Option[Int])
     val doc = BsonDocument()
-    val decoder = semiauto.deriveBsonDecoder[Simple]
-    decoder.decode(doc) should ===(Right(Simple(None)))
+    doc.fromBson[Simple] should ===(Right(Simple(None)))
   }
 
   it should "fail gracefully on nested decoders" in {


### PR DESCRIPTION
Instead of extending from default instances again in the `auto`
package object, we use a different pattern now:

1) `auto` only provides an `implicit val` of the
   `AutoDerivationUnlocker`
2) the companions of `BsonEncoder` and `BsonDecoder` provide the
   generic instances, but locked behind the `AutoDerivationUnlocker`
   implicit parameter.  The instance has the lowest priority of all
   provided instances
3) by importing the `auto` package object, the unlocker is in scope
   and the generic auto derivation kicks in if needed