### PR TITLE
CoproductDerivationOptions and cleanup

### DIFF
--- a/src/main/scala/medeia/generic/CoproductDecoderInstances.scala
+++ b/src/main/scala/medeia/generic/CoproductDecoderInstances.scala
@@ -1,0 +1,42 @@
+package medeia.generic
+
+import cats.data.NonEmptyChain
+import medeia.decoder.BsonDecoderError.InvalidTypeTag
+import medeia.decoder.{BsonDecoder, BsonDecoderError}
+import medeia.generic.util.VersionSpecific.Lazy
+import medeia.syntax._
+import shapeless.labelled.{FieldType, field}
+import shapeless.{:+:, CNil, Coproduct, Inl, Inr, Witness}
+
+trait CoproductDecoderInstances {
+  implicit def cnilDecoder[Base](
+      implicit options: CoproductDerivationOptions[Base] = CoproductDerivationOptions[Base]()): ShapelessDecoder[Base, CNil] = { bsonDocument =>
+    val typeTag = bsonDocument.getSafe(options.typeNameKey).flatMap(_.fromBson[String])
+    typeTag match {
+      case Left(value)  => Left(value)
+      case Right(value) => Left(NonEmptyChain(InvalidTypeTag(value)))
+    }
+  }
+
+  implicit def coproductDecoder[Base, K <: Symbol, H, T <: Coproduct](
+      implicit
+      witness: Witness.Aux[K],
+      hInstance: Lazy[BsonDecoder[H]],
+      tInstance: ShapelessDecoder[Base, T],
+      options: CoproductDerivationOptions[Base] = CoproductDerivationOptions[Base]()
+  ): ShapelessDecoder[Base, FieldType[K, H] :+: T] = { bsonDocument =>
+    val instanceTypeTag = options.transformTypeNames(witness.value.name)
+    def doDecode(typeTag: String): Either[NonEmptyChain[BsonDecoderError], FieldType[K, H] :+: T] = {
+      if (typeTag == instanceTypeTag) {
+        hInstance.value.decode(bsonDocument).map((x: H) => Inl(field[K](x)))
+      } else {
+        tInstance.decode(bsonDocument).map(Inr(_))
+      }
+    }
+    for {
+      typeField <- bsonDocument.getSafe(options.typeNameKey)
+      typeTag <- typeField.fromBson[String]
+      result <- doDecode(typeTag)
+    } yield result
+  }
+}

--- a/src/main/scala/medeia/generic/CoproductDerivationOptions.scala
+++ b/src/main/scala/medeia/generic/CoproductDerivationOptions.scala
@@ -1,0 +1,8 @@
+package medeia.generic
+
+case class CoproductDerivationOptions[A](
+    typeNameTransformation: PartialFunction[String, String] = PartialFunction.empty,
+    typeNameKey: String = "type"
+) {
+  val transformTypeNames: String => String = typeNameTransformation.orElse { case x => x }
+}

--- a/src/main/scala/medeia/generic/CoproductEncoderInstances.scala
+++ b/src/main/scala/medeia/generic/CoproductEncoderInstances.scala
@@ -1,0 +1,21 @@
+package medeia.generic
+
+import medeia.encoder.BsonDocumentEncoder
+import medeia.generic.util.VersionSpecific.Lazy
+import org.mongodb.scala.bson.BsonString
+import shapeless.labelled.FieldType
+import shapeless.{:+:, CNil, Coproduct, Inl, Inr, Witness}
+
+trait CoproductEncoderInstances {
+  implicit def cnilEncoder[Base]: ShapelessEncoder[Base, CNil] = _ => throw new Exception("Inconceivable!")
+  implicit def coproductEncoder[Base, K <: Symbol, H, T <: Coproduct](
+      implicit
+      witness: Witness.Aux[K],
+      hEncoder: Lazy[BsonDocumentEncoder[H]],
+      tEncoder: ShapelessEncoder[Base, T],
+      options: CoproductDerivationOptions[Base] = CoproductDerivationOptions[Base]()
+  ): ShapelessEncoder[Base, FieldType[K, H] :+: T] = {
+    case Inl(head) => hEncoder.value.encode(head).append(options.typeNameKey, BsonString(options.transformTypeNames(witness.value.name)))
+    case Inr(tail) => tEncoder.encode(tail)
+  }
+}

--- a/src/main/scala/medeia/generic/CoproductEncoderInstances.scala
+++ b/src/main/scala/medeia/generic/CoproductEncoderInstances.scala
@@ -15,7 +15,7 @@ trait CoproductEncoderInstances {
       tEncoder: ShapelessEncoder[Base, T],
       options: SealedTraitDerivationOptions[Base] = SealedTraitDerivationOptions[Base]()
   ): ShapelessEncoder[Base, FieldType[K, H] :+: T] = {
-    case Inl(head) => hEncoder.value.encode(head).append(options.typeTag, BsonString(options.transformTypeNames(witness.value.name)))
+    case Inl(head) => hEncoder.value.encode(head).append(options.discriminatorKey, BsonString(options.transformDiscriminator(witness.value.name)))
     case Inr(tail) => tEncoder.encode(tail)
   }
 }

--- a/src/main/scala/medeia/generic/CoproductEncoderInstances.scala
+++ b/src/main/scala/medeia/generic/CoproductEncoderInstances.scala
@@ -13,9 +13,9 @@ trait CoproductEncoderInstances {
       witness: Witness.Aux[K],
       hEncoder: Lazy[BsonDocumentEncoder[H]],
       tEncoder: ShapelessEncoder[Base, T],
-      options: CoproductDerivationOptions[Base] = CoproductDerivationOptions[Base]()
+      options: SealedTraitDerivationOptions[Base] = SealedTraitDerivationOptions[Base]()
   ): ShapelessEncoder[Base, FieldType[K, H] :+: T] = {
-    case Inl(head) => hEncoder.value.encode(head).append(options.typeNameKey, BsonString(options.transformTypeNames(witness.value.name)))
+    case Inl(head) => hEncoder.value.encode(head).append(options.typeTag, BsonString(options.transformTypeNames(witness.value.name)))
     case Inr(tail) => tEncoder.encode(tail)
   }
 }

--- a/src/main/scala/medeia/generic/HlistDecoderInstances.scala
+++ b/src/main/scala/medeia/generic/HlistDecoderInstances.scala
@@ -1,0 +1,33 @@
+package medeia.generic
+
+import cats.data.{EitherNec, NonEmptyChain}
+import cats.instances.either._
+import cats.syntax.parallel._
+import medeia.decoder.BsonDecoderError.KeyNotFound
+import medeia.decoder.{BsonDecoder, BsonDecoderError}
+import medeia.generic.util.VersionSpecific.Lazy
+import org.mongodb.scala.bson.BsonDocument
+import shapeless.labelled.{FieldType, field}
+import shapeless.{::, HList, HNil, Witness}
+
+trait HlistDecoderInstances {
+  implicit def hnilDecoder[Base]: ShapelessDecoder[Base, HNil] = _ => Right(HNil)
+
+  implicit def hlistObjectDecoder[Base, K <: Symbol, H, T <: HList](
+      implicit
+      witness: Witness.Aux[K],
+      hDecoder: Lazy[BsonDecoder[H]],
+      tDecoder: ShapelessDecoder[Base, T],
+      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()): ShapelessDecoder[Base, FieldType[K, H] :: T] = {
+    val fieldName: String = options.transformKeys(witness.value.name)
+    bsonDocument: BsonDocument =>
+      {
+        val head: EitherNec[BsonDecoderError, FieldType[K, H]] = Option(bsonDocument.get(fieldName)) match {
+          case Some(headField) => hDecoder.value.decode(headField).map(field[K](_))
+          case None            => hDecoder.value.defaultValue.map(field[K](_)).toRight(NonEmptyChain(KeyNotFound(fieldName)))
+        }
+        val tail = tDecoder.decode(bsonDocument)
+        (head, tail).parMapN(_ :: _)
+      }
+  }
+}

--- a/src/main/scala/medeia/generic/HlistEncoderInstances.scala
+++ b/src/main/scala/medeia/generic/HlistEncoderInstances.scala
@@ -1,0 +1,28 @@
+package medeia.generic
+
+import medeia.encoder.BsonEncoder
+import medeia.generic.util.VersionSpecific.Lazy
+import org.mongodb.scala.bson.BsonDocument
+import shapeless.labelled.FieldType
+import shapeless.{::, HList, HNil, Witness}
+
+trait HlistEncoderInstances {
+  implicit def hnilEncoder[Base]: ShapelessEncoder[Base, HNil] =
+    _ => BsonDocument()
+
+  implicit def hlistObjectEncoder[Base, K <: Symbol, H, T <: HList](
+      implicit
+      witness: Witness.Aux[K],
+      hEncoder: Lazy[BsonEncoder[H]],
+      tEncoder: ShapelessEncoder[Base, T],
+      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()
+  ): ShapelessEncoder[Base, FieldType[K, H] :: T] = {
+    val fieldName: String = options.transformKeys(witness.value.name)
+    hlist =>
+      {
+        val head = hEncoder.value.encode(hlist.head)
+        val tail: BsonDocument = tEncoder.encode(hlist.tail)
+        tail.append(fieldName, head)
+      }
+  }
+}

--- a/src/main/scala/medeia/generic/SealedTraitDerivationOptions.scala
+++ b/src/main/scala/medeia/generic/SealedTraitDerivationOptions.scala
@@ -1,8 +1,8 @@
 package medeia.generic
 
-case class CoproductDerivationOptions[A](
+case class SealedTraitDerivationOptions[A](
     typeNameTransformation: PartialFunction[String, String] = PartialFunction.empty,
-    typeNameKey: String = "type"
+    typeTag: String = "type"
 ) {
   val transformTypeNames: String => String = typeNameTransformation.orElse { case x => x }
 }

--- a/src/main/scala/medeia/generic/SealedTraitDerivationOptions.scala
+++ b/src/main/scala/medeia/generic/SealedTraitDerivationOptions.scala
@@ -1,8 +1,8 @@
 package medeia.generic
 
 case class SealedTraitDerivationOptions[A](
-    typeNameTransformation: PartialFunction[String, String] = PartialFunction.empty,
-    typeTag: String = "type"
+    discriminatorTransformation: PartialFunction[String, String] = PartialFunction.empty,
+    discriminatorKey: String = "type"
 ) {
-  val transformTypeNames: String => String = typeNameTransformation.orElse { case x => x }
+  val transformDiscriminator: String => String = discriminatorTransformation.orElse { case x => x }
 }

--- a/src/main/scala/medeia/generic/ShapelessDecoder.scala
+++ b/src/main/scala/medeia/generic/ShapelessDecoder.scala
@@ -1,71 +1,12 @@
 package medeia.generic
 
-import cats.data.{EitherNec, NonEmptyChain}
-import cats.instances.either._
-import cats.syntax.parallel._
-import medeia.decoder.BsonDecoderError.{InvalidTypeTag, KeyNotFound}
-import medeia.decoder.{BsonDecoder, BsonDecoderError}
-import medeia.generic.util.VersionSpecific.Lazy
-import medeia.syntax._
+import cats.data.EitherNec
+import medeia.decoder.BsonDecoderError
 import org.mongodb.scala.bson.BsonDocument
-import shapeless.labelled.{FieldType, field}
-import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, Witness}
 
 trait ShapelessDecoder[Base, H] {
   def decode(bsonDocument: BsonDocument): EitherNec[BsonDecoderError, H]
   def map[B](f: H => B): ShapelessDecoder[Base, B] = x => this.decode(x).map(f(_))
 }
 
-object ShapelessDecoder extends HlistInstances with CoproductInstances
-
-trait HlistInstances {
-  implicit def hnilDecoder[Base]: ShapelessDecoder[Base, HNil] = _ => Right(HNil)
-
-  implicit def hlistObjectDecoder[Base, K <: Symbol, H, T <: HList](
-      implicit
-      witness: Witness.Aux[K],
-      hDecoder: Lazy[BsonDecoder[H]],
-      tDecoder: ShapelessDecoder[Base, T],
-      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()): ShapelessDecoder[Base, FieldType[K, H] :: T] = {
-    val fieldName: String = options.transformKeys(witness.value.name)
-    bsonDocument: BsonDocument =>
-      {
-        val head: EitherNec[BsonDecoderError, FieldType[K, H]] = Option(bsonDocument.get(fieldName)) match {
-          case Some(headField) => hDecoder.value.decode(headField).map(field[K](_))
-          case None            => hDecoder.value.defaultValue.map(field[K](_)).toRight(NonEmptyChain(KeyNotFound(fieldName)))
-        }
-        val tail = tDecoder.decode(bsonDocument)
-        (head, tail).parMapN(_ :: _)
-      }
-  }
-}
-
-trait CoproductInstances {
-  implicit def cnilDecoder[Base]: ShapelessDecoder[Base, CNil] = { bsonDocument =>
-    val typeTag = bsonDocument.get("type").fromBson[String]
-    typeTag match {
-      case Left(value)  => Left(value)
-      case Right(value) => Left(NonEmptyChain(InvalidTypeTag(value)))
-    }
-  }
-
-  implicit def coproductDecoder[Base, K <: Symbol, H, T <: Coproduct](
-      implicit
-      witness: Witness.Aux[K],
-      hInstance: Lazy[BsonDecoder[H]],
-      tInstance: ShapelessDecoder[Base, T]
-  ): ShapelessDecoder[Base, FieldType[K, H] :+: T] = { bsonDocument =>
-    def doDecode(typeTag: String): Either[NonEmptyChain[BsonDecoderError], FieldType[K, H] :+: T] = {
-      if (typeTag == witness.value.name) {
-        hInstance.value.decode(bsonDocument).map((x: H) => Inl(field[K](x)))
-      } else {
-        tInstance.decode(bsonDocument).map(Inr(_))
-      }
-    }
-    for {
-      typeField <- bsonDocument.getSafe("type")
-      typeTag <- typeField.fromBson[String]
-      result <- doDecode(typeTag)
-    } yield result
-  }
-}
+object ShapelessDecoder extends HlistDecoderInstances with CoproductDecoderInstances

--- a/src/main/scala/medeia/generic/ShapelessEncoder.scala
+++ b/src/main/scala/medeia/generic/ShapelessEncoder.scala
@@ -1,49 +1,9 @@
 package medeia.generic
 
-import medeia.encoder.{BsonDocumentEncoder, BsonEncoder}
-import medeia.generic.util.VersionSpecific.Lazy
-import org.mongodb.scala.bson.{BsonDocument, BsonString}
-import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, Witness}
-import shapeless.labelled.FieldType
+import org.mongodb.scala.bson.BsonDocument
 
 trait ShapelessEncoder[Base, H] {
   def encode(a: H): BsonDocument
 }
 
 object ShapelessEncoder extends HlistEncoderInstances with CoproductEncoderInstances
-trait HlistEncoderInstances {
-  implicit def hnilEncoder[Base]: ShapelessEncoder[Base, HNil] =
-    _ => BsonDocument()
-
-  implicit def hlistObjectEncoder[Base, K <: Symbol, H, T <: HList](
-      implicit
-      witness: Witness.Aux[K],
-      hEncoder: Lazy[BsonEncoder[H]],
-      tEncoder: ShapelessEncoder[Base, T],
-      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()
-  ): ShapelessEncoder[Base, FieldType[K, H] :: T] = {
-    val fieldName: String = options.transformKeys(witness.value.name)
-    hlist =>
-      {
-        val head = hEncoder.value.encode(hlist.head)
-        val tail: BsonDocument = tEncoder.encode(hlist.tail)
-        tail.append(fieldName, head)
-      }
-  }
-}
-
-trait CoproductEncoderInstances {
-  implicit def cnilEncoder[Base]: ShapelessEncoder[Base, CNil] = _ => throw new Exception("Inconceivable!")
-
-  implicit def coproductEncoder[Base, K <: Symbol, H, T <: Coproduct](
-      implicit
-      witness: Witness.Aux[K],
-      hEncoder: Lazy[BsonDocumentEncoder[H]],
-      tEncoder: ShapelessEncoder[Base, T]
-  ): ShapelessEncoder[Base, FieldType[K, H] :+: T] =
-    (a: FieldType[K, H] :+: T) =>
-      a match {
-        case Inl(head) => hEncoder.value.encode(head).append("type", BsonString(witness.value.name))
-        case Inr(tail) => tEncoder.encode(tail)
-    }
-}

--- a/src/test/scala/medeia/generic/GenericCodecProperties.scala
+++ b/src/test/scala/medeia/generic/GenericCodecProperties.scala
@@ -61,7 +61,7 @@ class GenericCodecProperties extends Properties("GenericEncoding") {
     case class B(int: Int) extends Trait
 
     implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
-      SealedTraitDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeTag = "otherType")
+      SealedTraitDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
     implicit val genericDerivationOptionsA: GenericDerivationOptions[A] = GenericDerivationOptions { case a => a.toLowerCase() }
     implicit val genericDerivationOptionsB: GenericDerivationOptions[B] = GenericDerivationOptions { case a => a.toUpperCase() }
     val encoder: BsonEncoder[Trait] = GenericEncoder.genericEncoder

--- a/src/test/scala/medeia/generic/GenericCodecProperties.scala
+++ b/src/test/scala/medeia/generic/GenericCodecProperties.scala
@@ -60,8 +60,8 @@ class GenericCodecProperties extends Properties("GenericEncoding") {
     case class A(stringField: String) extends Trait
     case class B(int: Int) extends Trait
 
-    implicit val coproductDerivationOptions: CoproductDerivationOptions[Trait] =
-      CoproductDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeNameKey = "otherType")
+    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
+      SealedTraitDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeTag = "otherType")
     implicit val genericDerivationOptionsA: GenericDerivationOptions[A] = GenericDerivationOptions { case a => a.toLowerCase() }
     implicit val genericDerivationOptionsB: GenericDerivationOptions[B] = GenericDerivationOptions { case a => a.toUpperCase() }
     val encoder: BsonEncoder[Trait] = GenericEncoder.genericEncoder

--- a/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -64,8 +64,8 @@ class GenericDecoderSpec extends MedeiaSpec {
     sealed trait Trait
     case class A(string: String) extends Trait
     case class B(int: Int) extends Trait
-    implicit val coproductDerivationOptions: CoproductDerivationOptions[Trait] =
-      CoproductDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeNameKey = "otherType")
+    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
+      SealedTraitDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeTag = "otherType")
   }
 
   it should "decode sealed trait hierarchies with transformation" in {

--- a/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -41,7 +41,7 @@ class GenericEncoderSpec extends MedeiaSpec {
   //prevents unused field warnings
   object ForSealedTraitWithTransformationTest {
     implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
-      SealedTraitDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeTag = "otherType")
+      SealedTraitDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
   }
 
   it should "encode sealed trait hierarchies with transformation" in {

--- a/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -40,8 +40,8 @@ class GenericEncoderSpec extends MedeiaSpec {
 
   //prevents unused field warnings
   object ForSealedTraitWithTransformationTest {
-    implicit val coproductDerivationOptions: CoproductDerivationOptions[Trait] =
-      CoproductDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeNameKey = "otherType")
+    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
+      SealedTraitDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeTag = "otherType")
   }
 
   it should "encode sealed trait hierarchies with transformation" in {

--- a/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -7,20 +7,31 @@ import org.mongodb.scala.bson.BsonDocument
 
 class GenericEncoderSpec extends MedeiaSpec {
 
-  "GenericEncoder" should "allow for key transformation" in {
+  behavior of "GenericEncoder"
+
+  //prevents unused field warnings
+  object ForKeyTransformationTest {
     case class Simple(int: Int, string: String)
+    implicit val decoderOptions: GenericDerivationOptions[Simple] = GenericDerivationOptions { case "int" => "intA" }
+  }
+  it should "allow for key transformation" in {
+    import ForKeyTransformationTest._
 
     val simple = Simple(1, "string")
 
-    implicit val decoderOptions: GenericDerivationOptions[Simple] = GenericDerivationOptions { case "int" => "intA" }
     val document: BsonDocument = simple.toBsonDocument
     document.get("intA").asInt32().getValue should ===(1)
   }
 
-  it should "encode selead trait hierarchies" in {
+  //prevents unused field warnings
+  object ForSealedTraitTest {
     sealed trait Trait
     case class A(string: String) extends Trait
     case class B(int: Int) extends Trait
+  }
+
+  it should "encode selead trait hierarchies" in {
+    import ForSealedTraitTest._
 
     val original: Trait = A("asd")
     val document: BsonDocument = original.toBsonDocument
@@ -28,6 +39,27 @@ class GenericEncoderSpec extends MedeiaSpec {
       BsonDocument(
         "type" -> "A",
         "string" -> "asd"
+      ))
+  }
+
+  //prevents unused field warnings
+  object ForSealedTraitWithTransformationTest {
+    sealed trait Trait
+    case class A(string: String) extends Trait
+    case class B(int: Int) extends Trait
+    implicit val coproductDerivationOptions: CoproductDerivationOptions[Trait] =
+      CoproductDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeNameKey = "otherType")
+  }
+
+  it should "encode sealed trait hierarchies with transformation" in {
+    import medeia.generic.auto._
+    import ForSealedTraitWithTransformationTest._
+    val original: Trait = B(1)
+    val document: BsonDocument = original.toBsonDocument
+    document should ===(
+      BsonDocument(
+        "otherType" -> "b",
+        "int" -> 1
       ))
   }
 

--- a/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -9,11 +9,16 @@ class GenericEncoderSpec extends MedeiaSpec {
 
   behavior of "GenericEncoder"
 
+  sealed trait Trait
+  case class A(string: String) extends Trait
+  case class B(int: Int) extends Trait
+  case class Simple(int: Int, string: String)
+
   //prevents unused field warnings
   object ForKeyTransformationTest {
-    case class Simple(int: Int, string: String)
     implicit val decoderOptions: GenericDerivationOptions[Simple] = GenericDerivationOptions { case "int" => "intA" }
   }
+
   it should "allow for key transformation" in {
     import ForKeyTransformationTest._
 
@@ -23,16 +28,7 @@ class GenericEncoderSpec extends MedeiaSpec {
     document.get("intA").asInt32().getValue should ===(1)
   }
 
-  //prevents unused field warnings
-  object ForSealedTraitTest {
-    sealed trait Trait
-    case class A(string: String) extends Trait
-    case class B(int: Int) extends Trait
-  }
-
   it should "encode selead trait hierarchies" in {
-    import ForSealedTraitTest._
-
     val original: Trait = A("asd")
     val document: BsonDocument = original.toBsonDocument
     document should ===(
@@ -44,9 +40,6 @@ class GenericEncoderSpec extends MedeiaSpec {
 
   //prevents unused field warnings
   object ForSealedTraitWithTransformationTest {
-    sealed trait Trait
-    case class A(string: String) extends Trait
-    case class B(int: Int) extends Trait
     implicit val coproductDerivationOptions: CoproductDerivationOptions[Trait] =
       CoproductDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeNameKey = "otherType")
   }


### PR DESCRIPTION
Adds derivation options for coproducts.
Allowing to customize the fieldname of the type tag and transformation of the type tag string representation.