### PR TITLE
Make CoproductOptions contravariant

### DIFF
--- a/src/main/scala/medeia/generic/CoproductDerivationOptions.scala
+++ b/src/main/scala/medeia/generic/CoproductDerivationOptions.scala
@@ -1,6 +1,6 @@
 package medeia.generic
 
-case class CoproductDerivationOptions[A](
+case class CoproductDerivationOptions[-A](
     typeNameTransformation: PartialFunction[String, String] = PartialFunction.empty,
     typeNameKey: String = "type"
 ) {

--- a/src/test/scala/medeia/generic/GenericCodecProperties.scala
+++ b/src/test/scala/medeia/generic/GenericCodecProperties.scala
@@ -62,8 +62,6 @@ class GenericCodecProperties extends Properties("GenericEncoding") {
 
     implicit val coproductDerivationOptions: CoproductDerivationOptions[Trait] =
       CoproductDerivationOptions(typeNameTransformation = { case a => a.toLowerCase() }, typeNameKey = "otherType")
-    implicit val genericDerivationOptionsA: GenericDerivationOptions[A] = GenericDerivationOptions { case a => a.toLowerCase() }
-    implicit val genericDerivationOptionsB: GenericDerivationOptions[B] = GenericDerivationOptions { case a => a.toUpperCase() }
     val encoder: BsonEncoder[Trait] = GenericEncoder.genericEncoder
     val decoder: BsonDecoder[Trait] = GenericDecoder.genericDecoder
     val codec: BsonCodec[Trait] = BsonCodec.fromEncoderAndDecoder(encoder, decoder)


### PR DESCRIPTION
This would allow us to only specify the coproduct options for the top level trait.

I hope this has no other unwanted implications, but at least it works for our simple test