### PR TITLE
Add ErrorStack to BsonDecoderError

### DIFF
--- a/core/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -7,7 +7,7 @@ import cats.data.{Chain, EitherNec, NonEmptyChain, NonEmptyList, NonEmptySet}
 import cats.syntax.either._
 import cats.syntax.parallel._
 import medeia.decoder.BsonDecoderError.{FieldParseError, TypeMismatch}
-import medeia.decoder.StackFrame.{Index, MapKey}
+import medeia.decoder.StackFrame.{Case, Index, MapKey}
 import medeia.generic.GenericDecoder
 import medeia.generic.auto.AutoDerivationUnlocked
 import medeia.generic.util.VersionSpecific.Lazy
@@ -90,7 +90,7 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
       override def decode(bson: BsonValue): EitherNec[BsonDecoderError, Option[A]] =
         bson.getBsonType match {
           case BsonType.NULL => Either.rightNec(None)
-          case _             => BsonDecoder[A].decode(bson).map(Some(_))
+          case _             => BsonDecoder[A].decode(bson).map(Some(_)).leftMap(_.map(_.push(Case("Some"))))
         }
 
       override def defaultValue: Option[Option[A]] = Some(None)

--- a/core/src/main/scala/medeia/decoder/BsonDecoderError.scala
+++ b/core/src/main/scala/medeia/decoder/BsonDecoderError.scala
@@ -1,23 +1,41 @@
 package medeia.decoder
 
+import medeia.decoder.BsonDecoderError._
 import org.bson.BsonType
 
-trait BsonDecoderError extends Exception
+sealed trait BsonDecoderError extends Exception {
+  def stack: ErrorStack
+
+  final def push(frame: StackFrame): BsonDecoderError =
+    this match {
+      case err @ TypeMismatch(_, _, _)        => err.copy(stack = err.stack.push(frame))
+      case err @ KeyNotFound(_, _)            => err.copy(stack = err.stack.push(frame))
+      case err @ FieldParseError(_, _, _)     => err.copy(stack = err.stack.push(frame))
+      case err @ InvalidTypeTag(_, _)         => err.copy(stack = err.stack.push(frame))
+      case err @ GenericDecoderError(_, _, _) => err.copy(stack = err.stack.push(frame))
+    }
+}
 
 object BsonDecoderError {
-  final case class TypeMismatch(actual: BsonType, expected: BsonType)
-      extends Exception(s"expected: ${expected.toString}, actual: ${actual.toString}")
+  final case class TypeMismatch(actual: BsonType, expected: BsonType, stack: ErrorStack = ErrorStack.empty)
+      extends Exception(s"expected: ${expected.toString}, actual: ${actual.toString}, stack: ${stack.toString}")
       with BsonDecoderError
 
-  final case class KeyNotFound(keyName: String) extends Exception(s"Key not found: $keyName") with BsonDecoderError
+  final case class KeyNotFound(keyName: String, stack: ErrorStack = ErrorStack.empty)
+      extends Exception(s"Key not found: $keyName, stack: ${stack.toString}")
+      with BsonDecoderError
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  final case class FieldParseError(message: String, cause: Exception = null) extends Exception(message, cause) with BsonDecoderError
+  final case class FieldParseError(message: String, cause: Exception = null, stack: ErrorStack = ErrorStack.empty)
+      extends Exception(s"$message, stack: ${stack.toString}", cause)
+      with BsonDecoderError
 
-  final case class InvalidTypeTag(typeTag: String)
+  final case class InvalidTypeTag(typeTag: String, stack: ErrorStack = ErrorStack.empty)
       extends Exception(s"Trying to decode sealed trait, but no match found for typetag: $typeTag")
       with BsonDecoderError
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  final case class GenericDecoderError(message: String, cause: Exception = null) extends Exception(message, cause) with BsonDecoderError
+  final case class GenericDecoderError(message: String, cause: Exception = null, stack: ErrorStack = ErrorStack.empty)
+      extends Exception(s"$message, stack: ${stack.toString}", cause)
+      with BsonDecoderError
 }

--- a/core/src/main/scala/medeia/decoder/ErrorStack.scala
+++ b/core/src/main/scala/medeia/decoder/ErrorStack.scala
@@ -1,0 +1,21 @@
+package medeia.decoder
+
+final case class ErrorStack(frames: List[StackFrame]) {
+  def push(frame: StackFrame): ErrorStack = ErrorStack(frame +: frames)
+
+  override def toString: String =
+    frames.mkString("ErrorStack(", " -> ", ")")
+}
+
+object ErrorStack {
+  val empty: ErrorStack = ErrorStack(List.empty)
+}
+
+sealed trait StackFrame extends Product with Serializable
+object StackFrame {
+  final case class Attr(name: String) extends StackFrame
+  final case class Case(name: String) extends StackFrame
+  final case class Index(value: Int) extends StackFrame
+  final case class MapKey[A](value: A) extends StackFrame
+  final case class Custom(name: String) extends StackFrame
+}

--- a/core/src/main/scala/medeia/generic/CoproductDecoderInstances.scala
+++ b/core/src/main/scala/medeia/generic/CoproductDecoderInstances.scala
@@ -2,7 +2,9 @@ package medeia.generic
 
 import cats.data.NonEmptyChain
 import cats.syntax.eq._
+import cats.syntax.either._
 import medeia.decoder.BsonDecoderError.InvalidTypeTag
+import medeia.decoder.StackFrame.Case
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.generic.util.VersionSpecific.Lazy
 import medeia.syntax._
@@ -27,13 +29,15 @@ trait CoproductDecoderInstances {
       options: SealedTraitDerivationOptions[Base] = SealedTraitDerivationOptions[Base]()
   ): ShapelessDecoder[Base, FieldType[K, H] :+: T] = { bsonDocument =>
     val instanceDiscriminator = options.transformDiscriminator(witness.value.name)
+
     def doDecode(discriminatorFromBson: String): Either[NonEmptyChain[BsonDecoderError], FieldType[K, H] :+: T] = {
       if (discriminatorFromBson === instanceDiscriminator) {
-        hInstance.value.decode(bsonDocument).map((x: H) => Inl(field[K](x)))
+        hInstance.value.decode(bsonDocument).map((x: H) => Inl(field[K](x))).leftMap(_.map(_.push(Case(instanceDiscriminator))))
       } else {
         tInstance.decode(bsonDocument).map(Inr(_))
       }
     }
+
     for {
       discriminatorField <- bsonDocument.getSafe(options.discriminatorKey)
       discriminatorFromBson <- discriminatorField.fromBson[String]

--- a/core/src/main/scala/medeia/generic/HlistDecoderInstances.scala
+++ b/core/src/main/scala/medeia/generic/HlistDecoderInstances.scala
@@ -1,11 +1,11 @@
 package medeia.generic
 
-import cats.data.{EitherNec, NonEmptyChain}
+import cats.data.NonEmptyChain
+import cats.syntax.either._
 import cats.syntax.parallel._
+import medeia.decoder.BsonDecoder
 import medeia.decoder.BsonDecoderError.KeyNotFound
-import medeia.decoder.{BsonDecoder, BsonDecoderError}
-import medeia.generic.util.VersionSpecific.Lazy
-import org.mongodb.scala.bson.BsonDocument
+import medeia.decoder.StackFrame.Attr
 import shapeless.labelled.{FieldType, field}
 import shapeless.{::, HList, HNil, Witness}
 
@@ -14,18 +14,19 @@ trait HlistDecoderInstances {
 
   implicit def hlistObjectDecoder[Base, K <: Symbol, H, T <: HList](implicit
       witness: Witness.Aux[K],
-      hDecoder: Lazy[BsonDecoder[H]],
+      hDecoder: BsonDecoder[H],
       tDecoder: ShapelessDecoder[Base, T],
       options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()
-  ): ShapelessDecoder[Base, FieldType[K, H] :: T] = {
-    val fieldName: String = options.transformKeys(witness.value.name)
-    bsonDocument: BsonDocument => {
-      val head: EitherNec[BsonDecoderError, FieldType[K, H]] = Option(bsonDocument.get(fieldName)) match {
-        case Some(headField) => hDecoder.value.decode(headField).map(field[K](_))
-        case None            => hDecoder.value.defaultValue.map(field[K](_)).toRight(NonEmptyChain(KeyNotFound(fieldName)))
+  ): ShapelessDecoder[Base, FieldType[K, H] :: T] =
+    bsonDocument => {
+      val fieldName: String = options.transformKeys(witness.value.name)
+
+      val head = Option(bsonDocument.get(fieldName)) match {
+        case Some(headField) => hDecoder.decode(headField).map(field[K](_)).leftMap(_.map(_.push(Attr(fieldName))))
+        case None            => hDecoder.defaultValue.map(field[K](_)).toRight(NonEmptyChain(KeyNotFound(fieldName)))
       }
       val tail = tDecoder.decode(bsonDocument)
+
       (head, tail).parMapN(_ :: _)
     }
-  }
 }

--- a/core/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
+++ b/core/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
@@ -1,9 +1,11 @@
 package medeia.decoder
 
+import cats.data.NonEmptyChain
 import medeia.MedeiaSpec
+import medeia.decoder.StackFrame.{Index, MapKey}
 import org.bson.BsonValue
 import org.mongodb.scala.bson.collection.{immutable, mutable}
-import org.mongodb.scala.bson.{BsonDocument, BsonElement, BsonInt32, BsonString}
+import org.mongodb.scala.bson.{BsonArray, BsonDocument, BsonElement, BsonInt32, BsonString}
 
 import scala.jdk.CollectionConverters._
 
@@ -32,5 +34,22 @@ class BsonDecoderSpec extends MedeiaSpec {
     val bsonValue: BsonValue = new BsonString("")
 
     BsonDecoder[BsonValue].decode(bsonValue) should ===(Right(bsonValue))
+  }
+
+  it should "provide field info when failing to decode a map" in {
+    val key = "foo"
+    val doc = new BsonDocument(key, BsonString(""))
+
+    val result = BsonDecoder[Map[String, Int]].decode(doc)
+
+    result.left.value.head.stack should ===(ErrorStack(List(MapKey(key))))
+  }
+
+  it should "provide index info when failing to decode an iterable" in {
+    val bsonValue: BsonValue = new BsonArray(List(new BsonString("valid"), new BsonInt32(42), new BsonString("valid"), new BsonInt32(1337)).asJava)
+
+    val result = BsonDecoder[List[String]].decode(bsonValue)
+
+    result.left.value.map(_.stack) should ===(NonEmptyChain.of(ErrorStack(List(Index(1))), ErrorStack(List(Index(3)))))
   }
 }

--- a/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -139,7 +139,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     result.left.value.map(_.stack).toChain.toList should contain theSameElementsAs List(
       ErrorStack(List(Attr("foo"), Attr("i"))),
       ErrorStack(List(Attr("bar"), Attr("baz"), Index(0), Case("Qux"))),
-      ErrorStack(List(Attr("bar"), Attr("baz"), Index(1), Case("Qux"), Attr("answer")))
+      ErrorStack(List(Attr("bar"), Attr("baz"), Index(2), Case("Qux"), Attr("answer")))
     )
   }
 }

--- a/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -139,7 +139,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     result.left.value.map(_.stack).toChain.toList should contain theSameElementsAs List(
       ErrorStack(List(Attr("foo"), Attr("i"))),
       ErrorStack(List(Attr("bar"), Attr("baz"), Index(0), Case("Qux"))),
-      ErrorStack(List(Attr("bar"), Attr("baz"), Index(2), Case("Qux"), Attr("answer")))
+      ErrorStack(List(Attr("bar"), Attr("baz"), Index(1), Case("Qux"), Attr("answer")))
     )
   }
 }


### PR DESCRIPTION
This allows us to provide better help on errors, by providing a
"Stack" that directly points to the error. For example:

```
ErrorStack(List(Attr("bar"), Attr("baz"), Index(2), Case("Qux"), Attr("answer")))
```

says that we looked into the case class attribute `bar.baz`, at index `2`, the sealed trait case `Qux`, the case class attribute `answer` and **that's** where the error occurred.

Thoughts?

### Implementation Notes ###

- I made the `ErrorStack` attribute default to `ErrorStack.empty` in order to not break any existing code (hopefully).   
- I sealed the `BsonDecodeError` in order to be able to push `ErrorStackFrames` on it, this would also be potentially breaking if somebody inherits from it