### PR TITLE
Add iemap on BsonCodec

### DIFF
--- a/core/src/main/scala/medeia/codec/BsonCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonCodec.scala
@@ -2,8 +2,7 @@ package medeia.codec
 
 import cats.Invariant
 import cats.data.EitherNec
-import cats.syntax.either._
-import medeia.decoder.BsonDecoderError.GenericDecoderError
+import medeia.codec.BsonCodec.fromEncoderAndDecoder
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.encoder.BsonEncoder
 import medeia.generic.{GenericDecoder, GenericEncoder}
@@ -18,13 +17,7 @@ trait BsonCodec[A] extends BsonEncoder[A] with BsonDecoder[A] { self =>
       override def encode(value: B): BsonValue = self.encode(g(value))
     }
 
-  def iemap[B](f: A => Either[String, B])(g: B => A): BsonCodec[B] =
-    new BsonCodec[B] {
-      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
-        self.decode(bson).flatMap(f(_).leftMap(GenericDecoderError(_)).toEitherNec)
-
-      override def encode(value: B): BsonValue = self.encode(g(value))
-    }
+  def iemap[B](f: A => Either[String, B])(g: B => A): BsonCodec[B] = fromEncoderAndDecoder(contramap(g), emap(f))
 }
 
 object BsonCodec {

--- a/core/src/main/scala/medeia/codec/BsonCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonCodec.scala
@@ -8,14 +8,8 @@ import medeia.encoder.BsonEncoder
 import medeia.generic.{GenericDecoder, GenericEncoder}
 import org.mongodb.scala.bson.BsonValue
 
-trait BsonCodec[A] extends BsonEncoder[A] with BsonDecoder[A] { self =>
-  def imap[B](f: A => B)(g: B => A): BsonCodec[B] =
-    new BsonCodec[B] {
-      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
-        self.decode(bson).map(f)
-
-      override def encode(value: B): BsonValue = self.encode(g(value))
-    }
+trait BsonCodec[A] extends BsonEncoder[A] with BsonDecoder[A] {
+  def imap[B](f: A => B)(g: B => A): BsonCodec[B] = fromEncoderAndDecoder(contramap(g), map(f))
 
   def iemap[B](f: A => Either[String, B])(g: B => A): BsonCodec[B] = fromEncoderAndDecoder(contramap(g), emap(f))
 }

--- a/core/src/main/scala/medeia/codec/BsonDocumentCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonDocumentCodec.scala
@@ -2,18 +2,13 @@ package medeia.codec
 
 import cats.Invariant
 import cats.data.EitherNec
+import medeia.codec.BsonDocumentCodec.fromEncoderAndDecoder
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.encoder.BsonDocumentEncoder
 import org.bson.{BsonDocument, BsonValue}
 
-trait BsonDocumentCodec[A] extends BsonCodec[A] with BsonDocumentEncoder[A] { self =>
-  override def imap[B](f: A => B)(g: B => A): BsonDocumentCodec[B] =
-    new BsonDocumentCodec[B] {
-      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, B] =
-        self.decode(bson).map(f)
-
-      override def encode(value: B): BsonDocument = self.encode(g(value))
-    }
+trait BsonDocumentCodec[A] extends BsonCodec[A] with BsonDocumentEncoder[A] {
+  override def imap[B](f: A => B)(g: B => A): BsonDocumentCodec[B] = fromEncoderAndDecoder(contramap(g), map(f))
 }
 
 object BsonDocumentCodec {

--- a/core/src/main/scala/medeia/codec/BsonDocumentCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonDocumentCodec.scala
@@ -9,6 +9,8 @@ import org.bson.{BsonDocument, BsonValue}
 
 trait BsonDocumentCodec[A] extends BsonCodec[A] with BsonDocumentEncoder[A] {
   override def imap[B](f: A => B)(g: B => A): BsonDocumentCodec[B] = fromEncoderAndDecoder(contramap(g), map(f))
+
+  override def iemap[B](f: A => Either[String, B])(g: B => A): BsonDocumentCodec[B] = fromEncoderAndDecoder(contramap(g), emap(f))
 }
 
 object BsonDocumentCodec {

--- a/core/src/main/scala/medeia/codec/BsonKeyCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonKeyCodec.scala
@@ -2,17 +2,14 @@ package medeia.codec
 
 import cats.Invariant
 import cats.data.EitherNec
-import medeia.decoder.{BsonKeyDecoder, BsonDecoderError}
+import medeia.codec.BsonKeyCodec.fromEncoderAndDecoder
+import medeia.decoder.{BsonDecoderError, BsonKeyDecoder}
 import medeia.encoder.BsonKeyEncoder
 
 trait BsonKeyCodec[A] extends BsonKeyEncoder[A] with BsonKeyDecoder[A] { self =>
-  def imap[B](f: A => B)(g: B => A): BsonKeyCodec[B] =
-    new BsonKeyCodec[B] {
-      override def decode(string: String): EitherNec[BsonDecoderError, B] =
-        self.decode(string).map(f)
+  def imap[B](f: A => B)(g: B => A): BsonKeyCodec[B] = fromEncoderAndDecoder(contramap(g), map(f))
 
-      override def encode(value: B): String = self.encode(g(value))
-    }
+  def iemap[B](f: A => Either[String, B])(g: B => A): BsonKeyCodec[B] = fromEncoderAndDecoder(contramap(g), emap(f))
 }
 
 object BsonKeyCodec {

--- a/core/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -6,7 +6,7 @@ import cats.{Functor, Order}
 import cats.data.{Chain, EitherNec, NonEmptyChain, NonEmptyList, NonEmptySet}
 import cats.syntax.either._
 import cats.syntax.parallel._
-import medeia.decoder.BsonDecoderError.{FieldParseError, TypeMismatch}
+import medeia.decoder.BsonDecoderError.{FieldParseError, GenericDecoderError, TypeMismatch}
 import medeia.decoder.StackFrame.{Case, Index, MapKey}
 import medeia.generic.GenericDecoder
 import medeia.generic.auto.AutoDerivationUnlocked
@@ -42,6 +42,9 @@ trait BsonDecoder[A] { self =>
   def defaultValue: Option[A] = None
 
   def map[B](f: A => B): BsonDecoder[B] = x => self.decode(x).map(f(_))
+
+  def emap[B](f: A => Either[String, B]): BsonDecoder[B] =
+    x => self.decode(x).flatMap(f(_).leftMap(GenericDecoderError(_)).toEitherNec)
 }
 
 object BsonDecoder extends DefaultBsonDecoderInstances {

--- a/core/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -119,11 +119,10 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
       val document = bsonDocumentDecoder.decode(bson)
       document.flatMap { doc: BsonDocument =>
         doc.asScala.toList
-          .parTraverse {
-            case (k, v) =>
-              val key = BsonKeyDecoder[K].decode(k)
-              val value = BsonDecoder[A].decode(v)
-              (key, value).parMapN((k, v) => k -> v).leftMap(_.map(_.push(MapKey(k))))
+          .parTraverse { case (k, v) =>
+            val key = BsonKeyDecoder[K].decode(k)
+            val value = BsonDecoder[A].decode(v)
+            (key, value).parMapN((k, v) => k -> v).leftMap(_.map(_.push(MapKey(k))))
           }
           .map(_.toMap)
       }

--- a/core/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
@@ -1,16 +1,18 @@
 package medeia.decoder
 
 import java.util.UUID
-
 import cats.Functor
 import cats.syntax.either._
 import cats.data.EitherNec
-import medeia.decoder.BsonDecoderError.FieldParseError
+import medeia.decoder.BsonDecoderError.{FieldParseError, GenericDecoderError}
 
 trait BsonKeyDecoder[A] { self =>
   def decode(key: String): EitherNec[BsonDecoderError, A]
 
   def map[B](f: A => B): BsonKeyDecoder[B] = (key: String) => self.decode(key).map(f)
+
+  def emap[B](f: A => Either[String, B]): BsonKeyDecoder[B] =
+    (key: String) => self.decode(key).flatMap(f(_).leftMap(GenericDecoderError(_)).toEitherNec)
 }
 
 object BsonKeyDecoder extends DefaultBsonKeyDecoderInstances {

--- a/core/src/test/scala/medeia/codec/BsonCodecSpec.scala
+++ b/core/src/test/scala/medeia/codec/BsonCodecSpec.scala
@@ -1,6 +1,8 @@
 package medeia.codec
 
+import cats.syntax.either._
 import medeia.MedeiaSpec
+import medeia.decoder.BsonDecoderError.GenericDecoderError
 
 class BsonCodecSpec extends MedeiaSpec {
   behavior of "BsonCodec"
@@ -14,5 +16,28 @@ class BsonCodecSpec extends MedeiaSpec {
     val result = imappedCodec.decode(imappedCodec.encode(input))
 
     result should ===(Right(input))
+  }
+
+  it should "support iemap" in {
+    val codec = BsonCodec[Int]
+    val iemappedCodec: BsonCodec[String] = codec.iemap(i => Right(i.toString))(_.toInt)
+
+    val input = "42"
+
+    val result = iemappedCodec.decode(iemappedCodec.encode(input))
+
+    result should ===(Right(input))
+  }
+
+  it should "handle failures in iemap" in {
+    val codec = BsonCodec[Int]
+
+    val error = "oops"
+
+    val iemappedCodec: BsonCodec[String] = codec.iemap(_ => Left(error))(_.toInt)
+
+    val result = iemappedCodec.decode(iemappedCodec.encode("42"))
+
+    result should ===(Left(GenericDecoderError(error)).toEitherNec)
   }
 }

--- a/core/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
+++ b/core/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
@@ -1,21 +1,45 @@
 package medeia.codec
 
+import cats.syntax.either._
 import medeia.MedeiaSpec
+import medeia.decoder.BsonDecoderError.GenericDecoderError
 
 class BsonDocumentCodecSpec extends MedeiaSpec {
   behavior of "BsonDocumentCodec"
 
+  case class Foo(answer: Int)
+  implicit val derivedCodec: BsonDocumentCodec[Foo] = BsonCodec.derive[Foo]
+
   it should "support imap" in {
-
-    case class Foo(answer: Int)
-    implicit val codec: BsonDocumentCodec[Foo] = BsonCodec.derive[Foo]
-
-    val imappedCodec: BsonDocumentCodec[Int] = codec.imap(_.answer)(Foo)
+    val imappedCodec: BsonDocumentCodec[Int] = derivedCodec.imap(_.answer)(Foo)
 
     val input = 42
 
     val result = imappedCodec.decode(imappedCodec.encode(input))
 
     result should ===(Right(input))
+  }
+
+  it should "support iemap" in {
+    val codec = BsonDocumentCodec[Foo]
+    val iemappedCodec: BsonDocumentCodec[Int] = codec.iemap(i => Right(i.answer))(Foo)
+
+    val input = 42
+
+    val result = iemappedCodec.decode(iemappedCodec.encode(input))
+
+    result should ===(Right(input))
+  }
+
+  it should "handle failures in iemap" in {
+    val codec = BsonDocumentCodec[Foo]
+
+    val error = "oops"
+
+    val iemappedCodec: BsonDocumentCodec[Int] = codec.iemap(_ => Left(error))(Foo)
+
+    val result = iemappedCodec.decode(iemappedCodec.encode(42))
+
+    result should ===(Left(GenericDecoderError(error)).toEitherNec)
   }
 }

--- a/core/src/test/scala/medeia/codec/BsonKeyCodecSpec.scala
+++ b/core/src/test/scala/medeia/codec/BsonKeyCodecSpec.scala
@@ -1,6 +1,8 @@
 package medeia.codec
 
 import medeia.MedeiaSpec
+import medeia.decoder.BsonDecoderError.GenericDecoderError
+import cats.syntax.either._
 
 class BsonKeyCodecSpec extends MedeiaSpec {
   behavior of "BsonKeyCodec"
@@ -14,5 +16,28 @@ class BsonKeyCodecSpec extends MedeiaSpec {
     val result = imappedCodec.decode(imappedCodec.encode(input))
 
     result should ===(Right(input))
+  }
+
+  it should "support iemap" in {
+    val codec = BsonKeyCodec[Int]
+    val iemappedCodec: BsonKeyCodec[String] = codec.iemap(i => Right(i.toString))(_.toInt)
+
+    val input = "42"
+
+    val result = iemappedCodec.decode(iemappedCodec.encode(input))
+
+    result should ===(Right(input))
+  }
+
+  it should "handle failures in iemap" in {
+    val codec = BsonKeyCodec[Int]
+
+    val error = "oops"
+
+    val iemappedCodec: BsonKeyCodec[String] = codec.iemap(_ => Left(error))(_.toInt)
+
+    val result = iemappedCodec.decode(iemappedCodec.encode("42"))
+
+    result should ===(Left(GenericDecoderError(error)).toEitherNec)
   }
 }


### PR DESCRIPTION
Addresses #202 

Is that it already? Do we want to add tests for that?

Does it make sense to add `emap` on `BsonDecoder` as well, [similar to Circe](https://github.com/circe/circe/blob/70e3c4e742ca0181f5c1ce5900e2c71f05ca7ca8/modules/core/shared/src/main/scala/io/circe/Decoder.scala#L326)? If so, we could probably reuse the implementation here.