### PR TITLE
Fail fast error semantics

### DIFF
--- a/core/src/main/scala-2/medeia/generic/CoproductDecoderInstances.scala
+++ b/core/src/main/scala-2/medeia/generic/CoproductDecoderInstances.scala
@@ -1,6 +1,5 @@
 package medeia.generic
 
-import cats.data.NonEmptyChain
 import cats.syntax.eq._
 import cats.syntax.either._
 import medeia.decoder.BsonDecoderError.InvalidTypeTag
@@ -17,7 +16,7 @@ private[medeia] trait CoproductDecoderInstances {
     val typeTag = bsonDocument.getSafe(options.discriminatorKey).flatMap(_.fromBson[String])
     typeTag match {
       case Left(value)  => Left(value)
-      case Right(value) => Left(NonEmptyChain(InvalidTypeTag(value)))
+      case Right(value) => Left(InvalidTypeTag(value))
     }
   }
 
@@ -29,9 +28,9 @@ private[medeia] trait CoproductDecoderInstances {
   ): ShapelessDecoder[Base, FieldType[K, H] :+: T] = { bsonDocument =>
     val instanceDiscriminator = options.transformDiscriminator(witness.value.name)
 
-    def doDecode(discriminatorFromBson: String): Either[NonEmptyChain[BsonDecoderError], FieldType[K, H] :+: T] = {
+    def doDecode(discriminatorFromBson: String): Either[BsonDecoderError, FieldType[K, H] :+: T] = {
       if (discriminatorFromBson === instanceDiscriminator) {
-        hInstance.decode(bsonDocument).map((x: H) => Inl(field[K](x))).leftMap(_.map(_.push(Case(instanceDiscriminator))))
+        hInstance.decode(bsonDocument).map((x: H) => Inl(field[K](x))).leftMap(_.push(Case(instanceDiscriminator)))
       } else {
         tInstance.decode(bsonDocument).map(Inr(_))
       }

--- a/core/src/main/scala-2/medeia/generic/GenericDecoderInstances.scala
+++ b/core/src/main/scala-2/medeia/generic/GenericDecoderInstances.scala
@@ -1,6 +1,5 @@
 package medeia.generic
 
-import cats.syntax.either._
 import medeia.decoder.BsonDecoderError.TypeMismatch
 import org.bson.BsonType
 import shapeless.LabelledGeneric
@@ -12,7 +11,7 @@ private[medeia] trait GenericDecoderInstances {
   ): GenericDecoder[Base] = { bson =>
     bson.getBsonType match {
       case BsonType.DOCUMENT => hDecoder.decode(bson.asDocument()).map(generic.from)
-      case t                 => Either.leftNec(TypeMismatch(t, BsonType.DOCUMENT))
+      case t                 => Left(TypeMismatch(t, BsonType.DOCUMENT))
     }
   }
 }

--- a/core/src/main/scala-2/medeia/generic/HlistDecoderInstances.scala
+++ b/core/src/main/scala-2/medeia/generic/HlistDecoderInstances.scala
@@ -26,6 +26,6 @@ private[medeia] trait HlistDecoderInstances {
         }
         tail <- tDecoder.decode(bsonDocument)
 
-      } yield (head:: tail)
+      } yield (head :: tail)
     }
 }

--- a/core/src/main/scala-2/medeia/generic/ShapelessDecoder.scala
+++ b/core/src/main/scala-2/medeia/generic/ShapelessDecoder.scala
@@ -1,11 +1,10 @@
 package medeia.generic
 
-import cats.data.EitherNec
 import medeia.decoder.BsonDecoderError
 import org.mongodb.scala.bson.BsonDocument
 
 private[medeia] trait ShapelessDecoder[Base, H] {
-  def decode(bsonDocument: BsonDocument): EitherNec[BsonDecoderError, H]
+  def decode(bsonDocument: BsonDocument): Either[BsonDecoderError, H]
   def map[B](f: H => B): ShapelessDecoder[Base, B] = x => this.decode(x).map(f(_))
 }
 

--- a/core/src/main/scala-3/medeia/generic/GenericDecoderInstances.scala
+++ b/core/src/main/scala-3/medeia/generic/GenericDecoderInstances.scala
@@ -42,7 +42,7 @@ private[medeia] trait GenericDecoderInstances {
     labelling.elemLabels.zipWithIndex
       .map { case (label, index) =>
         Option.when(discriminatorKey == options.transformDiscriminator(label)) {
-          inst.inject[EitherNec[BsonDecoderError, A]](index)(
+          inst.inject[Either[BsonDecoderError, A]](index)(
             [t <: A] => (rt: ProductDecoder[t]) => rt.decode(value).leftMap(_.map(_.push(Case(discriminatorKey))))
           )
         }
@@ -78,7 +78,7 @@ private object ProductDecoder {
       inst: => K0.ProductInstances[BsonDecoder, A],
       labelling: Labelling[A],
       options: GenericDerivationOptions[A]
-  ): EitherNec[BsonDecoderError, A] = {
+  ): Either[BsonDecoderError, A] = {
     val (acc, result) = inst.unfold[Accumulator](Accumulator(labelling.elemLabels, None))(
       [t] =>
         (acc: Accumulator, rt: BsonDecoder[t]) =>

--- a/core/src/main/scala/medeia/codec/BsonCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonCodec.scala
@@ -1,7 +1,6 @@
 package medeia.codec
 
 import cats.Invariant
-import cats.data.EitherNec
 import medeia.codec.BsonCodec.fromEncoderAndDecoder
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.encoder.BsonEncoder
@@ -20,7 +19,7 @@ object BsonCodec {
     new BsonCodec[A] {
       override def encode(a: A): BsonValue = encoder.encode(a)
 
-      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, A] =
+      override def decode(bson: BsonValue): Either[BsonDecoderError, A] =
         decoder.decode(bson)
     }
 

--- a/core/src/main/scala/medeia/codec/BsonDocumentCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonDocumentCodec.scala
@@ -1,7 +1,6 @@
 package medeia.codec
 
 import cats.Invariant
-import cats.data.EitherNec
 import medeia.codec.BsonDocumentCodec.fromEncoderAndDecoder
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.encoder.BsonDocumentEncoder
@@ -20,7 +19,7 @@ object BsonDocumentCodec extends BsonDocumentCodecVersionSpecific {
     new BsonDocumentCodec[A] {
       override def encode(a: A): BsonDocument = encoder.encode(a)
 
-      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, A] =
+      override def decode(bson: BsonValue): Either[BsonDecoderError, A] =
         decoder.decode(bson)
     }
 

--- a/core/src/main/scala/medeia/codec/BsonKeyCodec.scala
+++ b/core/src/main/scala/medeia/codec/BsonKeyCodec.scala
@@ -1,7 +1,6 @@
 package medeia.codec
 
 import cats.Invariant
-import cats.data.EitherNec
 import medeia.codec.BsonKeyCodec.fromEncoderAndDecoder
 import medeia.decoder.{BsonDecoderError, BsonKeyDecoder}
 import medeia.encoder.BsonKeyEncoder
@@ -19,7 +18,7 @@ object BsonKeyCodec {
     new BsonKeyCodec[A] {
       override def encode(a: A): String = encoder.encode(a)
 
-      override def decode(string: String): EitherNec[BsonDecoderError, A] =
+      override def decode(string: String): Either[BsonDecoderError, A] =
         decoder.decode(string)
     }
 

--- a/core/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -107,7 +107,7 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
       Either
         .catchOnly[IllformedLocaleException](new Locale.Builder().setLanguageTag(string).build())
         .leftMap(FieldParseError("Cannot parse locale", _))
-        
+
     }
 
   implicit val uriDecoder: BsonDecoder[URI] = bson =>
@@ -230,7 +230,7 @@ trait BsonIterableDecoder {
 
           bson.asArray.getValues.forEach { b =>
             val decoded = BsonDecoder[A].decode(b).leftMap(_.push(Index(i)))
-            elems = elems.flatMap(builder => decoded.map(dec => builder += dec))         
+            elems = elems.flatMap(builder => decoded.map(dec => builder += dec))
             i += 1
           }
 

--- a/core/src/main/scala/medeia/decoder/BsonDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonDecoder.scala
@@ -1,8 +1,7 @@
 package medeia.decoder
 
 import cats.data._
-import cats.syntax.either._
-import cats.syntax.parallel._
+import cats.syntax.all._
 import cats.{Functor, Order}
 import medeia.decoder.BsonDecoderError.{FieldParseError, GenericDecoderError, TypeMismatch}
 import medeia.decoder.StackFrame.{Case, Index, MapKey}
@@ -39,19 +38,19 @@ import java.util.IllformedLocaleException
 @FunctionalInterface
 trait BsonDecoder[A] { self =>
 
-  def decode(bson: BsonValue): EitherNec[BsonDecoderError, A]
+  def decode(bson: BsonValue): Either[BsonDecoderError, A]
   def defaultValue: Option[A] = None
 
   def map[B](f: A => B): BsonDecoder[B] = x => self.decode(x).map(f(_))
 
   def emap[B](f: A => Either[String, B]): BsonDecoder[B] =
-    x => self.decode(x).flatMap(f(_).leftMap(GenericDecoderError(_)).toEitherNec)
+    x => self.decode(x).flatMap(f(_).leftMap(GenericDecoderError(_)))
 }
 
 object BsonDecoder extends DefaultBsonDecoderInstances with BsonDecoderVersionSpecific {
   def apply[A: BsonDecoder]: BsonDecoder[A] = implicitly
 
-  def decode[A: BsonDecoder](bson: BsonValue): EitherNec[BsonDecoderError, A] = {
+  def decode[A: BsonDecoder](bson: BsonValue): Either[BsonDecoderError, A] = {
     BsonDecoder[A].decode(bson)
   }
 
@@ -73,8 +72,8 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
 
   implicit val instantDecoder: BsonDecoder[Instant] = bson =>
     bson.getBsonType match {
-      case BsonType.DATE_TIME => Either.rightNec(Instant.ofEpochMilli(bson.asDateTime().getValue))
-      case t                  => Either.leftNec(TypeMismatch(t, BsonType.DATE_TIME))
+      case BsonType.DATE_TIME => Right(Instant.ofEpochMilli(bson.asDateTime().getValue))
+      case t                  => Left(TypeMismatch(t, BsonType.DATE_TIME))
     }
 
   implicit val dateDecoder: BsonDecoder[Date] = instantDecoder.map(Date.from)
@@ -83,16 +82,16 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
 
   implicit val symbolDecoder: BsonDecoder[Symbol] = bson =>
     bson.getBsonType match {
-      case BsonType.SYMBOL => Either.rightNec(Symbol(bson.asSymbol().getSymbol))
-      case t               => Either.leftNec(TypeMismatch(t, BsonType.SYMBOL))
+      case BsonType.SYMBOL => Right(Symbol(bson.asSymbol().getSymbol))
+      case t               => Left(TypeMismatch(t, BsonType.SYMBOL))
     }
 
   implicit def optionDecoder[A: BsonDecoder]: BsonDecoder[Option[A]] =
     new BsonDecoder[Option[A]] {
-      override def decode(bson: BsonValue): EitherNec[BsonDecoderError, Option[A]] =
+      override def decode(bson: BsonValue): Either[BsonDecoderError, Option[A]] =
         bson.getBsonType match {
-          case BsonType.NULL => Either.rightNec(None)
-          case _             => BsonDecoder[A].decode(bson).map(Some(_)).leftMap(_.map(_.push(Case("Some"))))
+          case BsonType.NULL => Right(None)
+          case _             => BsonDecoder[A].decode(bson).map(Some(_)).leftMap(_.push(Case("Some")))
         }
 
       override def defaultValue: Option[Option[A]] = Some(None)
@@ -100,7 +99,7 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
 
   implicit val uuidDecoder: BsonDecoder[UUID] = bson =>
     stringDecoder.decode(bson).flatMap { string =>
-      Either.catchOnly[IllegalArgumentException](UUID.fromString(string)).leftMap(FieldParseError("Cannot parse UUID", _)).toEitherNec
+      Either.catchOnly[IllegalArgumentException](UUID.fromString(string)).leftMap(FieldParseError("Cannot parse UUID", _))
     }
 
   implicit val localeDecoder: BsonDecoder[Locale] = bson =>
@@ -108,12 +107,12 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
       Either
         .catchOnly[IllformedLocaleException](new Locale.Builder().setLanguageTag(string).build())
         .leftMap(FieldParseError("Cannot parse locale", _))
-        .toEitherNec
+        
     }
 
   implicit val uriDecoder: BsonDecoder[URI] = bson =>
     stringDecoder.decode(bson).flatMap { string =>
-      Either.catchOnly[IllegalArgumentException](URI.create(string)).leftMap(FieldParseError("Cannot parse URI", _)).toEitherNec
+      Either.catchOnly[IllegalArgumentException](URI.create(string)).leftMap(FieldParseError("Cannot parse URI", _))
     }
 
   implicit def listDecoder[A: BsonDecoder]: BsonDecoder[List[A]] = iterableDecoder
@@ -131,10 +130,11 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
       val document = bsonDocumentDecoder.decode(bson)
       document.flatMap { (doc: BsonDocument) =>
         doc.asScala.toList
-          .parTraverse { case (k, v) =>
-            val key = BsonKeyDecoder[K].decode(k)
-            val value = BsonDecoder[A].decode(v)
-            (key, value).parMapN((k, v) => k -> v).leftMap(_.map(_.push(MapKey(k))))
+          .traverse { case (k, v) =>
+            (for {
+              key <- BsonKeyDecoder[K].decode(k)
+              value <- BsonDecoder[A].decode(v)
+            } yield key -> value).leftMap(_.push(MapKey(k)))
           }
           .map(_.toMap)
       }
@@ -144,29 +144,29 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
     bson =>
       listDecoder[A]
         .decode(bson)
-        .flatMap(list => NonEmptyList.fromList(list).toRight(FieldParseError("NonEmptyList may not be empty")).toEitherNec)
+        .flatMap(list => NonEmptyList.fromList(list).toRight(FieldParseError("NonEmptyList may not be empty")))
 
   implicit def nonEmptyChainDecoder[A: BsonDecoder]: BsonDecoder[NonEmptyChain[A]] =
     bson =>
       chainDecoder[A]
         .decode(bson)
-        .flatMap(chain => NonEmptyChain.fromChain(chain).toRight(FieldParseError("NonEmptyChain may not be empty")).toEitherNec)
+        .flatMap(chain => NonEmptyChain.fromChain(chain).toRight(FieldParseError("NonEmptyChain may not be empty")))
 
   implicit def nonEmptySetDecoder[A: BsonDecoder: Order]: BsonDecoder[NonEmptySet[A]] = {
     import Order.catsKernelOrderingForOrder
     bson =>
       sortedSetDecoder[A]
         .decode(bson)
-        .flatMap(sortedSet => NonEmptySet.fromSet(sortedSet).toRight(FieldParseError("NonEmptySet may not be empty")).toEitherNec)
+        .flatMap(sortedSet => NonEmptySet.fromSet(sortedSet).toRight(FieldParseError("NonEmptySet may not be empty")))
   }
 
   implicit def nonEmptyMapDecoder[K: BsonKeyDecoder: Ordering, A: BsonDecoder]: BsonDecoder[NonEmptyMap[K, A]] =
     bson =>
       mapDecoder[K, A]
         .decode(bson)
-        .flatMap(map => NonEmptyMap.fromMap(SortedMap.from(map)).toRight(FieldParseError("NonEmptyMap may not be empty")).toEitherNec)
+        .flatMap(map => NonEmptyMap.fromMap(SortedMap.from(map)).toRight(FieldParseError("NonEmptyMap may not be empty")))
 
-  implicit val bsonValueDecoder: BsonDecoder[BsonValue] = Either.rightNec[BsonDecoderError, BsonValue](_)
+  implicit val bsonValueDecoder: BsonDecoder[BsonValue] = Right[BsonDecoderError, BsonValue](_)
 
   implicit val bsonArrayDecoder: BsonDecoder[BsonArray] = withType(BsonType.ARRAY)(_.asArray)
 
@@ -207,10 +207,10 @@ trait DefaultBsonDecoderInstances extends BsonIterableDecoder {
 
   implicit val mutableDocumentDecoder: BsonDecoder[mutable.Document] = withType(BsonType.DOCUMENT)(b => mutable.Document(b.asDocument))
 
-  private[this] def withType[A](expectedType: BsonType)(f: BsonValue => A)(bson: BsonValue): EitherNec[BsonDecoderError, A] =
+  private[this] def withType[A](expectedType: BsonType)(f: BsonValue => A)(bson: BsonValue): Either[BsonDecoderError, A] =
     bson.getBsonType match {
-      case `expectedType` => Either.rightNec(f(bson))
-      case _              => Either.leftNec(TypeMismatch(bson.getBsonType, expectedType))
+      case `expectedType` => Right(f(bson))
+      case _              => Left(TypeMismatch(bson.getBsonType, expectedType))
 
     }
 }
@@ -224,17 +224,17 @@ trait BsonIterableDecoder {
           type BuilderType = scala.collection.mutable.Builder[A, C[A]]
           val builder: BuilderType = factory.newBuilder
           @SuppressWarnings(Array("org.wartremover.warts.Var"))
-          var elems = Either.rightNec[BsonDecoderError, BuilderType](builder)
+          var elems: Either[BsonDecoderError, BuilderType] = Right(builder)
           @SuppressWarnings(Array("org.wartremover.warts.Var"))
           var i = 0
 
           bson.asArray.getValues.forEach { b =>
-            val decoded = BsonDecoder[A].decode(b).leftMap(_.map(_.push(Index(i))))
-            elems = (elems, decoded).parMapN((builder, dec) => builder += dec)
+            val decoded = BsonDecoder[A].decode(b).leftMap(_.push(Index(i)))
+            elems = elems.flatMap(builder => decoded.map(dec => builder += dec))         
             i += 1
           }
 
           elems.map(_.result())
-        case t => Either.leftNec(TypeMismatch(t, BsonType.ARRAY))
+        case t => Left(TypeMismatch(t, BsonType.ARRAY))
       }
 }

--- a/core/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
@@ -47,5 +47,5 @@ trait DefaultBsonKeyDecoderInstances {
     Either
       .catchOnly[IllformedLocaleException](new Locale.Builder().setLanguageTag(key).build())
       .leftMap(FieldParseError("Cannot parse locale", _))
-      
+
 }

--- a/core/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
+++ b/core/src/main/scala/medeia/decoder/BsonKeyDecoder.scala
@@ -3,24 +3,23 @@ package medeia.decoder
 import java.util.UUID
 import cats.Functor
 import cats.syntax.either._
-import cats.data.EitherNec
 import medeia.decoder.BsonDecoderError.{FieldParseError, GenericDecoderError}
 import java.util.Locale
 import java.util.IllformedLocaleException
 
 trait BsonKeyDecoder[A] { self =>
-  def decode(key: String): EitherNec[BsonDecoderError, A]
+  def decode(key: String): Either[BsonDecoderError, A]
 
   def map[B](f: A => B): BsonKeyDecoder[B] = (key: String) => self.decode(key).map(f)
 
   def emap[B](f: A => Either[String, B]): BsonKeyDecoder[B] =
-    (key: String) => self.decode(key).flatMap(f(_).leftMap(GenericDecoderError(_)).toEitherNec)
+    (key: String) => self.decode(key).flatMap(f(_).leftMap(GenericDecoderError(_)))
 }
 
 object BsonKeyDecoder extends DefaultBsonKeyDecoderInstances {
   def apply[A: BsonKeyDecoder]: BsonKeyDecoder[A] = implicitly
 
-  def decode[A: BsonKeyDecoder](key: String): EitherNec[BsonDecoderError, A] = {
+  def decode[A: BsonKeyDecoder](key: String): Either[BsonDecoderError, A] = {
     BsonKeyDecoder[A].decode(key)
   }
 
@@ -33,20 +32,20 @@ trait DefaultBsonKeyDecoderInstances {
   implicit val stringDecoder: BsonKeyDecoder[String] = key => Right(key)
 
   implicit val intDecoder: BsonKeyDecoder[Int] = key =>
-    Either.catchOnly[NumberFormatException](key.toInt).leftMap(FieldParseError("Cannot parse int", _)).toEitherNec
+    Either.catchOnly[NumberFormatException](key.toInt).leftMap(FieldParseError("Cannot parse int", _))
 
   implicit val longDecoder: BsonKeyDecoder[Long] = key =>
-    Either.catchOnly[NumberFormatException](key.toLong).leftMap(FieldParseError("Cannot parse long", _)).toEitherNec
+    Either.catchOnly[NumberFormatException](key.toLong).leftMap(FieldParseError("Cannot parse long", _))
 
   implicit val doubleDecoder: BsonKeyDecoder[Double] = key =>
-    Either.catchOnly[NumberFormatException](key.toDouble).leftMap(FieldParseError("Cannot parse double", _)).toEitherNec
+    Either.catchOnly[NumberFormatException](key.toDouble).leftMap(FieldParseError("Cannot parse double", _))
 
   implicit val uuidDecoder: BsonKeyDecoder[UUID] = key =>
-    Either.catchOnly[IllegalArgumentException](UUID.fromString(key)).leftMap(FieldParseError("Cannot parse UUID", _)).toEitherNec
+    Either.catchOnly[IllegalArgumentException](UUID.fromString(key)).leftMap(FieldParseError("Cannot parse UUID", _))
 
   implicit val localeDecoder: BsonKeyDecoder[Locale] = key =>
     Either
       .catchOnly[IllformedLocaleException](new Locale.Builder().setLanguageTag(key).build())
       .leftMap(FieldParseError("Cannot parse locale", _))
-      .toEitherNec
+      
 }

--- a/core/src/main/scala/medeia/syntax/MedeiaSyntax.scala
+++ b/core/src/main/scala/medeia/syntax/MedeiaSyntax.scala
@@ -1,7 +1,5 @@
 package medeia.syntax
 
-import cats.data.EitherNec
-import cats.data.NonEmptyChain
 import medeia.decoder.BsonDecoderError.KeyNotFound
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.encoder.{BsonDocumentEncoder, BsonEncoder}
@@ -16,18 +14,18 @@ trait MedeiaSyntax {
   }
 
   implicit class BsonDecoderOps(bsonValue: BsonValue) {
-    def fromBson[A: BsonDecoder]: EitherNec[BsonDecoderError, A] = BsonDecoder.decode(bsonValue)
+    def fromBson[A: BsonDecoder]: Either[BsonDecoderError, A] = BsonDecoder.decode(bsonValue)
   }
 
   implicit class BsonDecoderOpsForDocument(document: Document) {
-    def fromBson[A: BsonDecoder]: EitherNec[BsonDecoderError, A] = BsonDecoder.decode(document.toBsonDocument)
+    def fromBson[A: BsonDecoder]: Either[BsonDecoderError, A] = BsonDecoder.decode(document.toBsonDocument)
   }
 
   implicit class GetSafeOpsForDocument(document: Document) {
-    def getSafe(key: String): EitherNec[BsonDecoderError, BsonValue] = document.get(key).toRight(NonEmptyChain(KeyNotFound(key)))
+    def getSafe(key: String): Either[BsonDecoderError, BsonValue] = document.get(key).toRight(KeyNotFound(key))
   }
 
   implicit class GetSafeOpsForBsonDocument(document: BsonDocument) {
-    def getSafe(key: String): EitherNec[BsonDecoderError, BsonValue] = Option(document.get(key)).toRight(NonEmptyChain(KeyNotFound(key)))
+    def getSafe(key: String): Either[BsonDecoderError, BsonValue] = Option(document.get(key)).toRight(KeyNotFound(key))
   }
 }

--- a/core/src/test/scala/medeia/codec/BsonCodecSpec.scala
+++ b/core/src/test/scala/medeia/codec/BsonCodecSpec.scala
@@ -1,6 +1,5 @@
 package medeia.codec
 
-import cats.syntax.either._
 import medeia.MedeiaSpec
 import medeia.decoder.BsonDecoderError
 import medeia.decoder.BsonDecoderError.GenericDecoderError
@@ -39,6 +38,6 @@ class BsonCodecSpec extends MedeiaSpec {
 
     val result = iemappedCodec.decode(iemappedCodec.encode("42"))
 
-    result should ===(Left[BsonDecoderError, String](GenericDecoderError(error)).toEitherNec)
+    result should ===(Left[BsonDecoderError, String](GenericDecoderError(error)))
   }
 }

--- a/core/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
+++ b/core/src/test/scala/medeia/codec/BsonDocumentCodecSpec.scala
@@ -1,6 +1,5 @@
 package medeia.codec
 
-import cats.syntax.either._
 import medeia.MedeiaSpec
 import medeia.decoder.{BsonDecoder, BsonDecoderError}
 import medeia.decoder.BsonDecoderError.GenericDecoderError
@@ -42,7 +41,7 @@ class BsonDocumentCodecSpec extends MedeiaSpec {
 
     val result = emappedDecoder.decode(new BsonDocument("answer", new BsonInt32(42)))
 
-    result should ===(Left[BsonDecoderError, Int](GenericDecoderError(error)).toEitherNec)
+    result should ===(Left[BsonDecoderError, Int](GenericDecoderError(error)))
   }
 
   it should "support iemap" in {
@@ -65,6 +64,6 @@ class BsonDocumentCodecSpec extends MedeiaSpec {
 
     val result = iemappedCodec.decode(iemappedCodec.encode(42))
 
-    result should ===(Left[BsonDecoderError, Int](GenericDecoderError(error)).toEitherNec)
+    result should ===(Left[BsonDecoderError, Int](GenericDecoderError(error)))
   }
 }

--- a/core/src/test/scala/medeia/codec/BsonKeyCodecSpec.scala
+++ b/core/src/test/scala/medeia/codec/BsonKeyCodecSpec.scala
@@ -2,7 +2,6 @@ package medeia.codec
 
 import medeia.MedeiaSpec
 import medeia.decoder.BsonDecoderError.GenericDecoderError
-import cats.syntax.either._
 import medeia.decoder.BsonDecoderError
 
 class BsonKeyCodecSpec extends MedeiaSpec {
@@ -39,6 +38,6 @@ class BsonKeyCodecSpec extends MedeiaSpec {
 
     val result = iemappedCodec.decode(iemappedCodec.encode("42"))
 
-    result should ===(Left[BsonDecoderError, String](GenericDecoderError(error)).toEitherNec)
+    result should ===(Left[BsonDecoderError, String](GenericDecoderError(error)))
   }
 }

--- a/core/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
+++ b/core/src/test/scala/medeia/decoder/BsonDecoderSpec.scala
@@ -1,6 +1,5 @@
 package medeia.decoder
 
-import cats.data.{EitherNec, NonEmptyChain}
 import medeia.MedeiaSpec
 import medeia.decoder.BsonDecoderError.GenericDecoderError
 import medeia.decoder.StackFrame.{Case, Index, MapKey}
@@ -43,7 +42,7 @@ class BsonDecoderSpec extends MedeiaSpec {
 
     val result = BsonDecoder[Map[String, Int]].decode(doc)
 
-    result.left.value.head.stack should ===(ErrorStack(List(MapKey(key))))
+    result.left.value.stack should ===(ErrorStack(List(MapKey(key))))
   }
 
   it should "provide index info when failing to decode an iterable" in {
@@ -51,7 +50,7 @@ class BsonDecoderSpec extends MedeiaSpec {
 
     val result = BsonDecoder[List[String]].decode(bsonValue)
 
-    result.left.value.map(_.stack) should ===(NonEmptyChain.of(ErrorStack(List(Index(1))), ErrorStack(List(Index(3)))))
+    result.left.value.stack should ===(ErrorStack(List(Index(1))))
   }
 
   it should "provide an error stack when decoding an Option in the Some case" in {
@@ -59,7 +58,7 @@ class BsonDecoderSpec extends MedeiaSpec {
 
     val result = BsonDecoder[Option[Int]].decode(bsonValue)
 
-    result.left.value.head.stack.frames should ===(List(Case("Some")))
+    result.left.value.stack.frames should ===(List(Case("Some")))
   }
 
   it should "provide an error stack when decoding an iterable" in {
@@ -68,7 +67,7 @@ class BsonDecoderSpec extends MedeiaSpec {
 
     val result = decoder.decode(bsonValue)
 
-    result.left.value.head.stack.frames should ===(List(Index(0)))
+    result.left.value.stack.frames should ===(List(Index(0)))
   }
 
   it should "provide an error stack when decoding a map" in {
@@ -77,7 +76,7 @@ class BsonDecoderSpec extends MedeiaSpec {
 
     val result = BsonDecoder[Map[String, Int]].decode(bsonValue)
 
-    result.left.value.head.stack.frames should ===(List(MapKey(keyname)))
+    result.left.value.stack.frames should ===(List(MapKey(keyname)))
   }
 
   it should "support map" in {
@@ -100,8 +99,8 @@ class BsonDecoderSpec extends MedeiaSpec {
     val doc = new BsonInt32(42)
 
     val error = "oops"
-    val result: EitherNec[BsonDecoderError, String] = BsonDecoder[Int].emap[String](_ => Left(error)).decode(doc)
+    val result: Either[BsonDecoderError, String] = BsonDecoder[Int].emap[String](_ => Left(error)).decode(doc)
 
-    result should ===(Left(NonEmptyChain.of(GenericDecoderError(error))))
+    result should ===(Left(GenericDecoderError(error)))
   }
 }

--- a/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -131,8 +131,7 @@ class GenericDecoderSpec extends MedeiaSpec {
 
     val result = doc.fromBson[FooBar]
 
-    result.left.value.stack should  ===(
-      ErrorStack(List(Attr("bar"), Attr("baz"), Index(0), Case("Qux"))))
+    result.left.value.stack should ===(ErrorStack(List(Attr("bar"), Attr("baz"), Index(0), Case("Qux"))))
   }
 
   it should "decode case objects" in {

--- a/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -1,6 +1,5 @@
 package medeia.generic
 
-import cats.data.NonEmptyChain
 import medeia.MedeiaSpec
 import medeia.decoder.BsonDecoder
 import medeia.decoder.BsonDecoderError.{InvalidTypeTag, KeyNotFound, TypeMismatch}
@@ -20,7 +19,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     case class Simple(int: Int, string: String)
     implicit val decoder: BsonDecoder[Simple] = BsonDecoder.derived
     val doc = BsonDocument()
-    doc.fromBson[Simple] should ===(Left(NonEmptyChain(KeyNotFound("int"), KeyNotFound("string"))))
+    doc.fromBson[Simple] should ===(Left(KeyNotFound("int")))
   }
 
   it should "decode empty values to None" in {
@@ -36,7 +35,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     case class Outer(inner: Inner)
     implicit val outerdecoder: BsonDecoder[Outer] = BsonDecoder.derived
     val doc = BsonDocument(List("inner" -> BsonNull()))
-    doc.fromBson[Outer] should ===(Left(NonEmptyChain(TypeMismatch(BsonType.NULL, BsonType.DOCUMENT, ErrorStack(List(Attr("inner")))))))
+    doc.fromBson[Outer] should ===(Left(TypeMismatch(BsonType.NULL, BsonType.DOCUMENT, ErrorStack(List(Attr("inner"))))))
   }
 
   it should "allow for key transformation" in {
@@ -87,7 +86,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result should ===(Left(NonEmptyChain(InvalidTypeTag("Z"))))
+    result should ===(Left(InvalidTypeTag("Z")))
   }
 
   it should "fail on missing discriminator" in {
@@ -97,7 +96,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result should ===(Left(NonEmptyChain(KeyNotFound("type"))))
+    result should ===(Left(KeyNotFound("type")))
   }
 
   it should "fail on invalid discriminator key" in {
@@ -108,7 +107,7 @@ class GenericDecoderSpec extends MedeiaSpec {
     )
 
     val result = original.fromBson[Trait]
-    result should ===(Left(NonEmptyChain(TypeMismatch(BsonType.INT32, BsonType.STRING))))
+    result should ===(Left(TypeMismatch(BsonType.INT32, BsonType.STRING)))
   }
 
   it should "fail with an error stack" in {
@@ -132,10 +131,8 @@ class GenericDecoderSpec extends MedeiaSpec {
 
     val result = doc.fromBson[FooBar]
 
-    result.left.value.map(_.stack).toChain.toList should contain theSameElementsAs List(
-      ErrorStack(List(Attr("bar"), Attr("baz"), Index(0), Case("Qux"))),
-      ErrorStack(List(Attr("bar"), Attr("baz"), Index(1), Case("Qux"), Attr("answer")))
-    )
+    result.left.value.stack should  ===(
+      ErrorStack(List(Attr("bar"), Attr("baz"), Index(0), Case("Qux"))))
   }
 
   it should "decode case objects" in {

--- a/core/src/test/scala/medeia/syntax/MedeiaSyntaxSpec.scala
+++ b/core/src/test/scala/medeia/syntax/MedeiaSyntaxSpec.scala
@@ -1,6 +1,5 @@
 package medeia.syntax
 
-import cats.data.NonEmptyChain
 import medeia.MedeiaSpec
 import medeia.codec.BsonDocumentCodec
 import medeia.decoder.BsonDecoderError.KeyNotFound
@@ -38,11 +37,11 @@ class MedeiaSyntaxSpec extends MedeiaSpec {
 
   it should "support getSafe for Document" in {
     Document("existing" -> "foo").getSafe("existing") should ===(Right(BsonString("foo")))
-    Document().getSafe("nonexisting") should ===(Left(NonEmptyChain(KeyNotFound("nonexisting"))))
+    Document().getSafe("nonexisting") should ===(Left(KeyNotFound("nonexisting")))
   }
 
   it should "support getSafe for BsonDocument" in {
     BsonDocument("existing" -> "foo").getSafe("existing") should ===(Right(BsonString("foo")))
-    BsonDocument().getSafe("nonexisting") should ===(Left(NonEmptyChain(KeyNotFound("nonexisting"))))
+    BsonDocument().getSafe("nonexisting") should ===(Left(KeyNotFound("nonexisting")))
   }
 }

--- a/modules/enumeratum/src/main/scala/medeia/enumeratum/Enumeratum.scala
+++ b/modules/enumeratum/src/main/scala/medeia/enumeratum/Enumeratum.scala
@@ -1,6 +1,5 @@
 package medeia.enumeratum
 
-import cats.data.EitherNec
 import cats.syntax.either._
 import enumeratum.values.{ValueEnum, ValueEnumEntry}
 import enumeratum.{Enum, EnumEntry}
@@ -33,13 +32,13 @@ object Enumeratum {
     BsonDecoder[ValueType]
       .decode(bson)
       .flatMap(value =>
-        Either.catchNonFatal(enumInstance.withValue(value)).leftMap(e => FieldParseError(s"Exception in enumeratum: ${e.getMessage}", e)).toEitherNec
+        Either.catchNonFatal(enumInstance.withValue(value)).leftMap(e => FieldParseError(s"Exception in enumeratum: ${e.getMessage}", e))
       )
 
   def valueEnumCodec[ValueType: BsonCodec, EntryType <: ValueEnumEntry[ValueType]](
       enumInstance: ValueEnum[ValueType, EntryType]
   ): BsonCodec[EntryType] = BsonCodec.fromEncoderAndDecoder(valueEnumEncoder, valueEnumDecoder(enumInstance))
 
-  private[this] def stringToEnum[A <: EnumEntry](enumInstance: Enum[A])(string: String): EitherNec[BsonDecoderError, A] =
-    Either.catchNonFatal(enumInstance.withName(string)).leftMap(e => FieldParseError(s"Exception in enumeratum: ${e.getMessage}", e)).toEitherNec
+  private[this] def stringToEnum[A <: EnumEntry](enumInstance: Enum[A])(string: String): Either[BsonDecoderError, A] =
+    Either.catchNonFatal(enumInstance.withName(string)).leftMap(e => FieldParseError(s"Exception in enumeratum: ${e.getMessage}", e))
 }

--- a/modules/enumeratum/src/test/scala/medeia/enumeratum/EnumeratumDecoderSpec.scala
+++ b/modules/enumeratum/src/test/scala/medeia/enumeratum/EnumeratumDecoderSpec.scala
@@ -13,12 +13,12 @@ class EnumeratumDecoderSpec extends AnyFlatSpecLike with TypeCheckedTripleEquals
   it should "Enum: fail gracefully on unknown entry" in {
     val unknown = "unknown"
 
-    Enumeratum.decoder(TestEnum).decode(BsonString(unknown)).left.value.head shouldBe a[FieldParseError]
+    Enumeratum.decoder(TestEnum).decode(BsonString(unknown)).left.value shouldBe a[FieldParseError]
   }
 
   it should "IntEnum: fail gracefully on unknown entry" in {
     val unknown = 42
 
-    Enumeratum.valueEnumDecoder(TestIntEnum).decode(BsonInt32(unknown)).left.value.head shouldBe a[FieldParseError]
+    Enumeratum.valueEnumDecoder(TestIntEnum).decode(BsonInt32(unknown)).left.value shouldBe a[FieldParseError]
   }
 }

--- a/modules/refined/src/main/scala/medeia/refined/package.scala
+++ b/modules/refined/src/main/scala/medeia/refined/package.scala
@@ -12,5 +12,5 @@ package object refined {
     innerEncoder.contramap(_.value)
 
   implicit def decoder[T, P](implicit innerDecoder: BsonDecoder[T], validate: Validate[T, P]): BsonDecoder[Refined[T, P]] =
-    bson => innerDecoder.decode(bson).flatMap(t => refineV[P](t).leftMap(error => GenericDecoderError(error)).toEitherNec)
+    bson => innerDecoder.decode(bson).flatMap(t => refineV[P](t).leftMap(error => GenericDecoderError(error)))
 }

--- a/modules/refined/src/test/scala/medeia/refined/RefinedDecoderSpec.scala
+++ b/modules/refined/src/test/scala/medeia/refined/RefinedDecoderSpec.scala
@@ -14,6 +14,6 @@ class RefinedDecoderSpec extends AnyFlatSpecLike with Matchers with EitherValues
 
   it should "fail gracefully on failed refinement" in {
     val incorrectString = BsonString("No UUID at all")
-    BsonDecoder[Refined[String, Uuid]].decode(incorrectString).left.value.head shouldBe a[GenericDecoderError]
+    BsonDecoder[Refined[String, Uuid]].decode(incorrectString).left.value shouldBe a[GenericDecoderError]
   }
 }


### PR DESCRIPTION
fixes #555 

migrate `EitherNec[BsonDecoderError, A]` to `Either[BsonDecoderError, A]`