### PR TITLE
Remove SealedTraitDerivationOptions

### DIFF
--- a/core/src/main/scala-2/medeia/generic/CoproductDecoderInstances.scala
+++ b/core/src/main/scala-2/medeia/generic/CoproductDecoderInstances.scala
@@ -12,7 +12,7 @@ import shapeless.{:+:, CNil, Coproduct, Inl, Inr, Witness}
 
 private[medeia] trait CoproductDecoderInstances {
   implicit def cnilDecoder[Base](implicit
-      options: SealedTraitDerivationOptions[Base] = SealedTraitDerivationOptions[Base]()
+      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()
   ): ShapelessDecoder[Base, CNil] = { bsonDocument =>
     val typeTag = bsonDocument.getSafe(options.discriminatorKey).flatMap(_.fromBson[String])
     typeTag match {
@@ -25,7 +25,7 @@ private[medeia] trait CoproductDecoderInstances {
       witness: Witness.Aux[K],
       hInstance: GenericDecoder[H],
       tInstance: ShapelessDecoder[Base, T],
-      options: SealedTraitDerivationOptions[Base] = SealedTraitDerivationOptions[Base]()
+      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()
   ): ShapelessDecoder[Base, FieldType[K, H] :+: T] = { bsonDocument =>
     val instanceDiscriminator = options.transformDiscriminator(witness.value.name)
 

--- a/core/src/main/scala-2/medeia/generic/CoproductEncoderInstances.scala
+++ b/core/src/main/scala-2/medeia/generic/CoproductEncoderInstances.scala
@@ -11,7 +11,7 @@ private[medeia] trait CoproductEncoderInstances {
       witness: Witness.Aux[K],
       hEncoder: GenericEncoder[H],
       tEncoder: ShapelessEncoder[Base, T],
-      options: SealedTraitDerivationOptions[Base] = SealedTraitDerivationOptions[Base]()
+      options: GenericDerivationOptions[Base] = GenericDerivationOptions[Base]()
   ): ShapelessEncoder[Base, FieldType[K, H] :+: T] = {
     case (Inl(head), _) =>
       hEncoder.encode(head).append(options.discriminatorKey, BsonString(options.transformDiscriminator(witness.value.name)))

--- a/core/src/main/scala-3/medeia/generic/GenericDecoderInstances.scala
+++ b/core/src/main/scala-3/medeia/generic/GenericDecoderInstances.scala
@@ -19,7 +19,7 @@ private[medeia] trait GenericDecoderInstances {
   given coproduct[A](using
       inst: => K0.CoproductInstances[ProductDecoder, A],
       labelling: Labelling[A],
-      options: SealedTraitDerivationOptions[A] = SealedTraitDerivationOptions[A]()
+      options: GenericDerivationOptions[A] = GenericDerivationOptions[A]()
   ): GenericDecoder[A] = { value =>
     for {
       document <- value.fromBson[BsonDocument]
@@ -37,7 +37,7 @@ private[medeia] trait GenericDecoderInstances {
   private def doDecode[A](discriminatorKey: String, value: BsonValue)(using
       inst: => K0.CoproductInstances[ProductDecoder, A],
       labelling: Labelling[A],
-      options: SealedTraitDerivationOptions[A]
+      options: GenericDerivationOptions[A]
   ) = {
     labelling.elemLabels.zipWithIndex
       .map { case (label, index) =>

--- a/core/src/main/scala-3/medeia/generic/GenericEncoderInstances.scala
+++ b/core/src/main/scala-3/medeia/generic/GenericEncoderInstances.scala
@@ -16,7 +16,7 @@ private[medeia] trait GenericEncoderInstances {
       inst: => K0.CoproductInstances[ProductEncoder, A],
       labelling: Labelling[A],
       mirror: Mirror.SumOf[A],
-      options: SealedTraitDerivationOptions[A] = SealedTraitDerivationOptions[A]()
+      options: GenericDerivationOptions[A] = GenericDerivationOptions[A]()
   ): GenericEncoder[A] =
     (value: A) => {
       inst.fold(value)(

--- a/core/src/main/scala/medeia/generic/GenericDerivationOptions.scala
+++ b/core/src/main/scala/medeia/generic/GenericDerivationOptions.scala
@@ -1,5 +1,10 @@
 package medeia.generic
 
-final case class GenericDerivationOptions[A](keyTransformation: PartialFunction[String, String] = PartialFunction.empty) {
+final case class GenericDerivationOptions[A](
+    keyTransformation: PartialFunction[String, String] = PartialFunction.empty,
+    discriminatorTransformation: PartialFunction[String, String] = PartialFunction.empty,
+    discriminatorKey: String = "type"
+) {
   val transformKeys: String => String = keyTransformation.orElse { case x => x }
+  val transformDiscriminator: String => String = discriminatorTransformation.orElse { case x => x }
 }

--- a/core/src/main/scala/medeia/generic/SealedTraitDerivationOptions.scala
+++ b/core/src/main/scala/medeia/generic/SealedTraitDerivationOptions.scala
@@ -1,8 +1,0 @@
-package medeia.generic
-
-final case class SealedTraitDerivationOptions[A](
-    discriminatorTransformation: PartialFunction[String, String] = PartialFunction.empty,
-    discriminatorKey: String = "type"
-) {
-  val transformDiscriminator: String => String = discriminatorTransformation.orElse { case x => x }
-}

--- a/core/src/test/scala-3/medeia/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/medeia/Scala3DerivesSpec.scala
@@ -30,8 +30,8 @@ class Scala3DerivesSpec extends MedeiaSpec {
   case class B(int: Int) extends Trait
 
   object Trait {
-    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
-      SealedTraitDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
+    implicit val coproductDerivationOptions: GenericDerivationOptions[Trait] =
+      GenericDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
   }
   object A {
     implicit val genericDerivationOptionsA: GenericDerivationOptions[A] = GenericDerivationOptions { case a => a.toLowerCase() }
@@ -58,8 +58,8 @@ class Scala3DerivesSpec extends MedeiaSpec {
     case B2(int: Int)
 
   object TestEnum {
-    given SealedTraitDerivationOptions[TestEnum] =
-      SealedTraitDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
+    given GenericDerivationOptions[TestEnum] =
+      GenericDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
     given GenericDerivationOptions[A1] = GenericDerivationOptions { case a => a.toLowerCase() }
     given GenericDerivationOptions[B2] = GenericDerivationOptions { case a => a.toUpperCase() }
     given BsonDocumentCodec[A1] = BsonDocumentCodec.derived

--- a/core/src/test/scala/medeia/generic/GenericCodecProperties.scala
+++ b/core/src/test/scala/medeia/generic/GenericCodecProperties.scala
@@ -55,8 +55,8 @@ class GenericCodecProperties extends Properties("GenericEncoding") {
     case class A(stringField: String) extends Trait
     case class B(int: Int) extends Trait
 
-    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
-      SealedTraitDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
+    implicit val coproductDerivationOptions: GenericDerivationOptions[Trait] =
+      GenericDerivationOptions(discriminatorTransformation = { case a => a.toLowerCase() }, discriminatorKey = "otherType")
     val codec: BsonCodec[Trait] = BsonDocumentCodec.derived
   }
 

--- a/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericDecoderSpec.scala
@@ -63,8 +63,8 @@ class GenericDecoderSpec extends MedeiaSpec {
 
   // prevents unused field warnings
   object ForSealedTraitWithTransformationTest {
-    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
-      SealedTraitDerivationOptions(discriminatorTransformation = { case d => d.toLowerCase() }, discriminatorKey = "otherType")
+    implicit val coproductDerivationOptions: GenericDerivationOptions[Trait] =
+      GenericDerivationOptions(discriminatorTransformation = { case d => d.toLowerCase() }, discriminatorKey = "otherType")
     implicit val decoder: BsonDecoder[Trait] = BsonDecoder.derived
   }
 

--- a/core/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -67,7 +67,7 @@ class GenericEncoderSpec extends MedeiaSpec {
     implicit val traitDerivationOptions: GenericDerivationOptions[Trait] =
       GenericDerivationOptions(
         discriminatorTransformation = { case d => d.toLowerCase() },
-        discriminatorKey = "otherType",
+        discriminatorKey = "otherType"
       )
     implicit val caseClassDerivationOptions: GenericDerivationOptions[A] =
       GenericDerivationOptions(

--- a/core/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -17,8 +17,6 @@ class GenericEncoderSpec extends MedeiaSpec {
   case class Simple(int: Int, string: String)
 
   object DefaultTraitEncoders {
-    implicit val encoderA: BsonDocumentEncoder[A] = BsonDocumentEncoder.derived
-    implicit val encoderB: BsonDocumentEncoder[B.type] = BsonDocumentEncoder.derived
     implicit val encoder: BsonDocumentEncoder[Trait] = BsonDocumentEncoder.derived
   }
 
@@ -66,10 +64,15 @@ class GenericEncoderSpec extends MedeiaSpec {
 
   // prevents unused field warnings
   object ForSealedTraitWithTransformationTest {
-    implicit val coproductDerivationOptions: GenericDerivationOptions[Trait] =
-      GenericDerivationOptions(discriminatorTransformation = { case d => d.toLowerCase() }, discriminatorKey = "otherType")
-    implicit val encoderA: BsonDocumentEncoder[A] = BsonDocumentEncoder.derived
-    implicit val encoderB: BsonDocumentEncoder[B.type] = BsonDocumentEncoder.derived
+    implicit val traitDerivationOptions: GenericDerivationOptions[Trait] =
+      GenericDerivationOptions(
+        discriminatorTransformation = { case d => d.toLowerCase() },
+        discriminatorKey = "otherType",
+      )
+    implicit val caseClassDerivationOptions: GenericDerivationOptions[A] =
+      GenericDerivationOptions(
+        keyTransformation = { case d => d.toUpperCase() }
+      )
     implicit val encoder: BsonDocumentEncoder[Trait] = BsonDocumentEncoder.derived
   }
 
@@ -80,7 +83,7 @@ class GenericEncoderSpec extends MedeiaSpec {
     document should ===(
       BsonDocument(
         "otherType" -> "a",
-        "string" -> "1"
+        "STRING" -> "1"
       )
     )
   }

--- a/core/src/test/scala/medeia/generic/GenericEncoderSpec.scala
+++ b/core/src/test/scala/medeia/generic/GenericEncoderSpec.scala
@@ -66,8 +66,8 @@ class GenericEncoderSpec extends MedeiaSpec {
 
   // prevents unused field warnings
   object ForSealedTraitWithTransformationTest {
-    implicit val coproductDerivationOptions: SealedTraitDerivationOptions[Trait] =
-      SealedTraitDerivationOptions(discriminatorTransformation = { case d => d.toLowerCase() }, discriminatorKey = "otherType")
+    implicit val coproductDerivationOptions: GenericDerivationOptions[Trait] =
+      GenericDerivationOptions(discriminatorTransformation = { case d => d.toLowerCase() }, discriminatorKey = "otherType")
     implicit val encoderA: BsonDocumentEncoder[A] = BsonDocumentEncoder.derived
     implicit val encoderB: BsonDocumentEncoder[B.type] = BsonDocumentEncoder.derived
     implicit val encoder: BsonDocumentEncoder[Trait] = BsonDocumentEncoder.derived


### PR DESCRIPTION
This removes SealedTraitDerivationOptions and migrates Coproduct configuration to `GenericDerivationOptions`

fixes #552 